### PR TITLE
properly access the monaco dom node

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -57,7 +57,7 @@ firepad.Firepad = (function(global) {
     } else if (this.ace_) {
       editorWrapper = this.ace_.container;
     } else {
-      editorWrapper = this.monaco_.getDomNode()
+      editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
     // var editorWrapper = this.codeMirror_ ? this.codeMirror_.getWrapperElement() : this.ace_.container;
@@ -171,7 +171,7 @@ firepad.Firepad = (function(global) {
     } else if (this.ace_) {
         editorWrapper = this.ace_.container;
     } else {
-        editorWrapper = this.monaco_.getDomNode()
+        editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
     this.firepadWrapper_.removeChild(editorWrapper);


### PR DESCRIPTION
This PR fixes an error that occurs when trying to change the underlying `model` of a `Monaco` editor.  Firepad [wraps the editor in a `div`](https://github.com/CoderPad/firepad/blob/master/lib/firepad.js#L64), which leads to the following error being thrown when trying to access the editor: `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`.