### PR TITLE
feat(headless): expose isHistoryEmpty on Headless class

### DIFF
--- a/lib/headless.js
+++ b/lib/headless.js
@@ -10,6 +10,8 @@ firepad.Headless = (function() {
   var ParseHtml       = firepad.ParseHtml;
 
   function Headless(refOrPath) {
+    var self = this;
+
     // Allow calling without new.
     if (!(this instanceof Headless)) { return new Headless(refOrPath); }
 
@@ -33,6 +35,16 @@ firepad.Headless = (function() {
     this.firebaseAdapter_ = new FirebaseAdapter(ref);
     this.ready_ = false;
     this.zombie_ = false;
+
+    this.firebaseAdapter_.on('ready', function() {
+      self.ready_ = true;
+      self.trigger('ready');
+    })
+  }
+
+  Headless.prototype.isHistoryEmpty = function() {
+    this.assertReady_('isHistoryEmpty');
+    return this.firebaseAdapter_.isHistoryEmpty();
   }
 
   Headless.prototype.getDocument = function(callback) {
@@ -149,5 +161,17 @@ firepad.Headless = (function() {
     this.firebaseAdapter_.dispose();
   };
 
+  Headless.prototype.assertReady_ = function(funcName) {
+    if (!this.ready_) {
+      throw new Error('You must wait for the "ready" event before calling ' + funcName + '.');
+    }
+    if (this.zombie_) {
+      throw new Error("You can't use a Firepad after calling dispose()! [called " + funcName + "]");
+    }
+  }
+
   return Headless;
 })();
+
+firepad.utils.makeEventEmitter(firepad.Headless)
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderpad_io/firepad",
   "description": "Collaborative text editing powered by Firebase. As forked by Coderpad.io.",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
To simplify checking the history of document using a headless Firepad, expose an `isHistoryEmpty` method on the `Headless` class. The logic in `isHistoryEmpty` was borrowed from the [`Firepad` class](https://github.com/CoderPad/firepad/blob/master/lib/firepad.js#L305-L308).

Additionally, make `Headless` an event emitter so that it can notify a consumer application when is ready by emitting a `ready` event.