### PR TITLE
fix(monaco): make undo/redo actually work

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -272,7 +272,7 @@ var MonacoAdapter = function () {
    */
   MonacoAdapter.prototype.registerUndo = function registerUndo(callback) {
     if (typeof callback === 'function') {
-      this.callbacks.undo = callback;
+      this.monacoModel.undo = callback;
     } else {
       throw new Error('MonacoAdapter: registerUndo method expects a '
         + 'callback function in parameter');
@@ -285,7 +285,7 @@ var MonacoAdapter = function () {
    */
   MonacoAdapter.prototype.registerRedo = function registerRedo(callback) {
     if (typeof callback === 'function') {
-      this.callbacks.redo = callback;
+      this.monacoModel.redo = callback;
     } else {
       throw new Error('MonacoAdapter: registerRedo method expects a '
         + 'callback function in parameter');
@@ -498,7 +498,7 @@ var MonacoAdapter = function () {
    * @param {Operation} operation - OT.js Operation Object
    */
   MonacoAdapter.prototype.invertOperation = function invertOperation(operation) {
-    operation.invert(this.getValue());
+    return operation.invert(this.monacoModel.getValue());
   };
 
   return MonacoAdapter;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderpad_io/firepad",
   "description": "Collaborative text editing powered by Firebase. As forked by Coderpad.io.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
This PR fixes undo/redo functionality for `monaco` editors.  Undo/redo is totally broken for Monaco+Firepad currently, as it seems that Firepad is not receiving any undo/redo events from Monaco, and instead Monaco is handling all undo/redo requests (and conflating all changes, regardless of user, when maintaining its undo/redo stack).

As for the code itself, it seems there was an [implementation of this functionality](https://github.com/CoderPad/firepad/commit/251df18d8c94bb9c63dbde8c86f018c9df5fd197) that was added to firepad when the `monaco` adapter was first created.  A little while after that, the `monaco` adapter underwent a [major rewrite](https://github.com/CoderPad/firepad/commit/e39b4c147d6f41a246cb56232a0d6fc33833fd59), and was merged in despite the maintainers admittedly [not having fully verified the changes](https://github.com/FirebaseExtended/firepad/pull/325).  This commit broke the connection between `monacoModel.undo`/`redo` and Firepad's adapters for managing stacks that are user-dependent.

[ Interestingly, the author of the offending commit above is a primary contributor to [interviewstreet/firepad-x](https://github.com/interviewstreet/firepad-x), aka HackerRank.  Their version of firepad has undergone a major rewrite, and their `monaco-adapter` is an 800-line typescript file.  Makes me wonder what other bugs they've fixed there over the past few years... ]

I am not super confident in this fix, but it works in my testing so far.  I suspect there are some edge cases, tho I'm not sure yet how to raise them...