### PR TITLE
feat(firepad): Add options to Headless and pass userId to firebase adapter

### DIFF
--- a/lib/headless.js
+++ b/lib/headless.js
@@ -51,6 +51,14 @@ firepad.Headless = (function () {
     return option in this.options_ ? this.options_[option] : def
   }
 
+  Headless.prototype.setUserId = function (userId) {
+    this.firebaseAdapter_.setUserId(userId)
+  }
+
+  Headless.prototype.setUserColor = function (color) {
+    this.firebaseAdapter_.setColor(color)
+  }
+
   Headless.prototype.isHistoryEmpty = function () {
     this.assertReady_('isHistoryEmpty')
     return this.firebaseAdapter_.isHistoryEmpty()

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -14,7 +14,7 @@ firepad.Headless = (function () {
 
     // Allow calling without new.
     if (!(this instanceof Headless)) {
-      return new Headless(refOrPath)
+      return new Headless(refOrPath, options)
     }
 
     var firebase, ref

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -1,177 +1,185 @@
-var firepad = firepad || { };
+var firepad = firepad || {}
 
 /**
  * Instance of headless Firepad for use in NodeJS. Supports get/set on text/html.
  */
-firepad.Headless = (function() {
-  var TextOperation   = firepad.TextOperation;
-  var FirebaseAdapter = firepad.FirebaseAdapter;
-  var EntityManager   = firepad.EntityManager;
-  var ParseHtml       = firepad.ParseHtml;
+firepad.Headless = (function () {
+  var TextOperation = firepad.TextOperation
+  var FirebaseAdapter = firepad.FirebaseAdapter
+  var EntityManager = firepad.EntityManager
+  var ParseHtml = firepad.ParseHtml
 
-  function Headless(refOrPath) {
-    var self = this;
+  function Headless(refOrPath, options) {
+    var self = this
 
     // Allow calling without new.
-    if (!(this instanceof Headless)) { return new Headless(refOrPath); }
-
-    var firebase, ref;
-    if (typeof refOrPath === 'string') {
-      if (window.firebase === undefined && typeof firebase !== 'object') {
-        console.log("REQUIRING");
-        firebase = require('firebase/app');
-        require('firebase/database');
-      } else {
-        firebase = window.firebase;
-      }
-
-      ref = firebase.database().refFromURL(refOrPath);
-    } else {
-      ref = refOrPath;
+    if (!(this instanceof Headless)) {
+      return new Headless(refOrPath)
     }
 
-    this.entityManager_  = new EntityManager();
+    var firebase, ref
+    if (typeof refOrPath === 'string') {
+      if (window.firebase === undefined && typeof firebase !== 'object') {
+        console.log('REQUIRING')
+        firebase = require('firebase/app')
+        require('firebase/database')
+      } else {
+        firebase = window.firebase
+      }
 
-    this.firebaseAdapter_ = new FirebaseAdapter(ref);
-    this.ready_ = false;
-    this.zombie_ = false;
+      ref = firebase.database().refFromURL(refOrPath)
+    } else {
+      ref = refOrPath
+    }
 
-    this.firebaseAdapter_.on('ready', function() {
-      self.ready_ = true;
-      self.trigger('ready');
+    this.entityManager_ = new EntityManager()
+
+    this.options_ = options || {}
+    var userId = this.getOption('userId')
+
+    this.firebaseAdapter_ = new FirebaseAdapter(ref, userId)
+    this.ready_ = false
+    this.zombie_ = false
+
+    this.firebaseAdapter_.on('ready', function () {
+      self.ready_ = true
+      self.trigger('ready')
     })
   }
 
-  Headless.prototype.isHistoryEmpty = function() {
-    this.assertReady_('isHistoryEmpty');
-    return this.firebaseAdapter_.isHistoryEmpty();
+  Headless.prototype.getOption = function (option, def) {
+    return option in this.options_ ? this.options_[option] : def
   }
 
-  Headless.prototype.getDocument = function(callback) {
-    var self = this;
+  Headless.prototype.isHistoryEmpty = function () {
+    this.assertReady_('isHistoryEmpty')
+    return this.firebaseAdapter_.isHistoryEmpty()
+  }
+
+  Headless.prototype.getDocument = function (callback) {
+    var self = this
 
     if (self.ready_) {
-      return callback(self.firebaseAdapter_.getDocument());
+      return callback(self.firebaseAdapter_.getDocument())
     }
 
-    self.firebaseAdapter_.on('ready', function() {
-      self.ready_ = true;
-      callback(self.firebaseAdapter_.getDocument());
-    });
+    self.firebaseAdapter_.on('ready', function () {
+      self.ready_ = true
+      callback(self.firebaseAdapter_.getDocument())
+    })
   }
 
-  Headless.prototype.getText = function(callback) {
+  Headless.prototype.getText = function (callback) {
     if (this.zombie_) {
-      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+      throw new Error("You can't use a firepad.Headless after calling dispose()!")
     }
 
-    this.getDocument(function(doc) {
-      var text = doc.apply('');
+    this.getDocument(function (doc) {
+      var text = doc.apply('')
 
       // Strip out any special characters from Rich Text formatting
       for (var key in firepad.sentinelConstants) {
-        text = text.replace(new RegExp(firepad.sentinelConstants[key], 'g'), '');
+        text = text.replace(new RegExp(firepad.sentinelConstants[key], 'g'), '')
       }
-      callback(text);
-    });
+      callback(text)
+    })
   }
 
-  Headless.prototype.setText = function(text, callback) {
+  Headless.prototype.setText = function (text, callback) {
     if (this.zombie_) {
-      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+      throw new Error("You can't use a firepad.Headless after calling dispose()!")
     }
 
-    var op = TextOperation().insert(text);
-    this.sendOperationWithRetry(op, callback);
+    var op = TextOperation().insert(text)
+    this.sendOperationWithRetry(op, callback)
   }
 
-  Headless.prototype.initializeFakeDom = function(callback) {
+  Headless.prototype.initializeFakeDom = function (callback) {
     if (typeof document === 'object' || typeof firepad.document === 'object') {
-      callback();
+      callback()
     } else {
-      const jsdom = require('jsdom');
-      const { JSDOM } = jsdom;
-      const { window } = new JSDOM("<head></head><body></body>");
+      const jsdom = require('jsdom')
+      const { JSDOM } = jsdom
+      const { window } = new JSDOM('<head></head><body></body>')
       if (firepad.document) {
         // Return if we've already made a jsdom to avoid making more than one
         // This would be easier with promises but we want to avoid introducing
         // another dependency for just headless mode.
-        window.close();
-        return callback();
+        window.close()
+        return callback()
       }
-      firepad.document = window.document;
-      callback();
+      firepad.document = window.document
+      callback()
     }
   }
 
-  Headless.prototype.getHtml = function(callback) {
-    var self = this;
+  Headless.prototype.getHtml = function (callback) {
+    var self = this
 
     if (this.zombie_) {
-      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+      throw new Error("You can't use a firepad.Headless after calling dispose()!")
     }
 
-    self.initializeFakeDom(function() {
-      self.getDocument(function(doc) {
-        callback(firepad.SerializeHtml(doc, self.entityManager_));
-      });
-    });
+    self.initializeFakeDom(function () {
+      self.getDocument(function (doc) {
+        callback(firepad.SerializeHtml(doc, self.entityManager_))
+      })
+    })
   }
 
-  Headless.prototype.setHtml = function(html, callback) {
-    var self = this;
+  Headless.prototype.setHtml = function (html, callback) {
+    var self = this
 
     if (this.zombie_) {
-      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+      throw new Error("You can't use a firepad.Headless after calling dispose()!")
     }
 
-    self.initializeFakeDom(function() {
-      var textPieces = ParseHtml(html, self.entityManager_);
-      var inserts    = firepad.textPiecesToInserts(true, textPieces);
-      var op         = new TextOperation();
+    self.initializeFakeDom(function () {
+      var textPieces = ParseHtml(html, self.entityManager_)
+      var inserts = firepad.textPiecesToInserts(true, textPieces)
+      var op = new TextOperation()
 
       for (var i = 0; i < inserts.length; i++) {
-        op.insert(inserts[i].string, inserts[i].attributes);
+        op.insert(inserts[i].string, inserts[i].attributes)
       }
 
-      self.sendOperationWithRetry(op, callback);
-    });
+      self.sendOperationWithRetry(op, callback)
+    })
   }
 
-  Headless.prototype.sendOperationWithRetry = function(operation, callback) {
-    var self = this;
+  Headless.prototype.sendOperationWithRetry = function (operation, callback) {
+    var self = this
 
-    self.getDocument(function(doc) {
-      var op = operation.clone()['delete'](doc.targetLength);
-      self.firebaseAdapter_.sendOperation(op, function(err, committed) {
+    self.getDocument(function (doc) {
+      var op = operation.clone()['delete'](doc.targetLength)
+      self.firebaseAdapter_.sendOperation(op, function (err, committed) {
         if (committed) {
-          if (typeof callback !== "undefined") {
-            callback(null, committed);
+          if (typeof callback !== 'undefined') {
+            callback(null, committed)
           }
         } else {
-          self.sendOperationWithRetry(operation, callback);
+          self.sendOperationWithRetry(operation, callback)
         }
-      });
-    });
+      })
+    })
   }
 
-  Headless.prototype.dispose = function() {
-    this.zombie_ = true; // We've been disposed.  No longer valid to do anything.
+  Headless.prototype.dispose = function () {
+    this.zombie_ = true // We've been disposed.  No longer valid to do anything.
 
-    this.firebaseAdapter_.dispose();
-  };
+    this.firebaseAdapter_.dispose()
+  }
 
-  Headless.prototype.assertReady_ = function(funcName) {
+  Headless.prototype.assertReady_ = function (funcName) {
     if (!this.ready_) {
-      throw new Error('You must wait for the "ready" event before calling ' + funcName + '.');
+      throw new Error('You must wait for the "ready" event before calling ' + funcName + '.')
     }
     if (this.zombie_) {
-      throw new Error("You can't use a Firepad after calling dispose()! [called " + funcName + "]");
+      throw new Error("You can't use a Firepad after calling dispose()! [called " + funcName + ']')
     }
   }
 
-  return Headless;
-})();
+  return Headless
+})()
 
 firepad.utils.makeEventEmitter(firepad.Headless)
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderpad_io/firepad",
   "description": "Collaborative text editing powered by Firebase. As forked by Coderpad.io.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
We want to use a headless Firepad to control the user and connections data for the global pad in an environments world. This PR adds an options arg to Headless that can contain a userId property, that will in turn be passed to Headless' FirebaseAdapter, which will cause the `connections` object for the user to be populated.

We also would like for a headless Firepad to be able to update the user's color in the same fashion as an editor Firepad. To accomplish this, I have added a `setUserColor` method to `Headless`.

Lots of auto-formatting changes here 😢  I'll comment in the diff which places actually changed. We'll have to format this file eventually anyway.