### PR TITLE
feat(firepad): add error events for invalid operation length

### DIFF
--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -192,8 +192,14 @@ firepad.EditorClient = (function () {
   }
 
   EditorClient.prototype.sendOperation = function (operation) {
-    this.serverAdapter.sendOperation(operation)
-    this.emitStatus()
+    try {
+      this.serverAdapter.sendOperation(operation)
+      this.emitStatus()
+    } catch (e) {
+      // Emit the error event and rethrow the exception.
+      this.trigger('error', e)
+      throw e
+    }
   }
 
   EditorClient.prototype.applyOperation = function (operation) {
@@ -224,4 +230,4 @@ firepad.EditorClient = (function () {
   return EditorClient
 })()
 
-firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced'])
+firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced', 'error'])

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -1,203 +1,227 @@
-var firepad = firepad || { };
+var firepad = firepad || {}
 
 firepad.EditorClient = (function () {
-  'use strict';
+  'use strict'
 
-  var Client = firepad.Client;
-  var Cursor = firepad.Cursor;
-  var UndoManager = firepad.UndoManager;
-  var WrappedOperation = firepad.WrappedOperation;
+  var Client = firepad.Client
+  var Cursor = firepad.Cursor
+  var UndoManager = firepad.UndoManager
+  var WrappedOperation = firepad.WrappedOperation
 
-  function SelfMeta (cursorBefore, cursorAfter) {
-    this.cursorBefore = cursorBefore;
-    this.cursorAfter  = cursorAfter;
+  function SelfMeta(cursorBefore, cursorAfter) {
+    this.cursorBefore = cursorBefore
+    this.cursorAfter = cursorAfter
   }
 
   SelfMeta.prototype.invert = function () {
-    return new SelfMeta(this.cursorAfter, this.cursorBefore);
-  };
+    return new SelfMeta(this.cursorAfter, this.cursorBefore)
+  }
 
   SelfMeta.prototype.compose = function (other) {
-    return new SelfMeta(this.cursorBefore, other.cursorAfter);
-  };
+    return new SelfMeta(this.cursorBefore, other.cursorAfter)
+  }
 
   SelfMeta.prototype.transform = function (operation) {
     return new SelfMeta(
       this.cursorBefore ? this.cursorBefore.transform(operation) : null,
       this.cursorAfter ? this.cursorAfter.transform(operation) : null
-    );
-  };
+    )
+  }
 
-  function OtherClient (id, editorAdapter) {
-    this.id = id;
-    this.editorAdapter = editorAdapter;
+  function OtherClient(id, editorAdapter) {
+    this.id = id
+    this.editorAdapter = editorAdapter
   }
 
   OtherClient.prototype.setColor = function (color) {
-    this.color = color;
-  };
+    this.color = color
+  }
 
   OtherClient.prototype.updateCursor = function (cursor) {
-    this.removeCursor();
-    this.cursor = cursor;
-    this.mark = this.editorAdapter.setOtherCursor(
-      cursor,
-      this.color,
-      this.id
-    );
-  };
+    this.removeCursor()
+    this.cursor = cursor
+    this.mark = this.editorAdapter.setOtherCursor(cursor, this.color, this.id)
+  }
 
   OtherClient.prototype.removeCursor = function () {
-    if (this.mark) { this.mark.clear(); }
-  };
+    if (this.mark) {
+      this.mark.clear()
+    }
+  }
 
-  function EditorClient (serverAdapter, editorAdapter) {
-    Client.call(this);
-    this.serverAdapter = serverAdapter;
-    this.editorAdapter = editorAdapter;
-    this.undoManager = new UndoManager();
+  function EditorClient(serverAdapter, editorAdapter) {
+    Client.call(this)
+    this.serverAdapter = serverAdapter
+    this.editorAdapter = editorAdapter
+    this.undoManager = new UndoManager()
 
-    this.clients = { };
+    this.clients = {}
 
-    var self = this;
+    var self = this
 
     this.editorAdapter.registerCallbacks({
-      change: function (operation, inverse) { self.onChange(operation, inverse); },
-      cursorActivity: function () { self.onCursorActivity(); },
-      blur: function () { self.onBlur(); },
-      focus: function () { self.onFocus(); }
-    });
-    this.editorAdapter.registerUndo(function () { self.undo(); });
-    this.editorAdapter.registerRedo(function () { self.redo(); });
+      change: function (operation, inverse) {
+        self.onChange(operation, inverse)
+      },
+      cursorActivity: function () {
+        self.onCursorActivity()
+      },
+      blur: function () {
+        self.onBlur()
+      },
+      focus: function () {
+        self.onFocus()
+      },
+    })
+    this.editorAdapter.registerUndo(function () {
+      self.undo()
+    })
+    this.editorAdapter.registerRedo(function () {
+      self.redo()
+    })
 
     this.serverAdapter.registerCallbacks({
       ack: function () {
-        self.serverAck();
+        self.serverAck()
         if (self.focused && self.state instanceof Client.Synchronized) {
-          self.updateCursor();
-          self.sendCursor(self.cursor);
+          self.updateCursor()
+          self.sendCursor(self.cursor)
         }
-        self.emitStatus();
+        self.emitStatus()
       },
-      retry: function() { self.serverRetry(); },
+      retry: function () {
+        self.serverRetry()
+      },
       operation: function (operation) {
-        self.applyServer(operation);
+        self.applyServer(operation)
       },
       cursor: function (clientId, cursor, color) {
-        if (self.serverAdapter.userId_ === clientId ||
-            !(self.state instanceof Client.Synchronized)) {
-          return;
+        if (self.serverAdapter.userId_ === clientId || !(self.state instanceof Client.Synchronized)) {
+          return
         }
-        var client = self.getClientObject(clientId);
+        var client = self.getClientObject(clientId)
         if (cursor) {
-          if (color) client.setColor(color);
-          client.updateCursor(Cursor.fromJSON(cursor));
+          if (color) client.setColor(color)
+          client.updateCursor(Cursor.fromJSON(cursor))
         } else {
-          client.removeCursor();
+          client.removeCursor()
         }
-      }
-    });
+      },
+    })
   }
 
-  inherit(EditorClient, Client);
+  inherit(EditorClient, Client)
 
   EditorClient.prototype.getClientObject = function (clientId) {
-    var client = this.clients[clientId];
-    if (client) { return client; }
-    return this.clients[clientId] = new OtherClient(
-      clientId,
-      this.editorAdapter
-    );
-  };
-
-  EditorClient.prototype.applyUnredo = function (operation) {
-    this.undoManager.add(this.editorAdapter.invertOperation(operation));
-    this.editorAdapter.applyOperation(operation.wrapped);
-    this.cursor = operation.meta.cursorAfter;
-    if (this.cursor)
-      this.editorAdapter.setCursor(this.cursor);
-    this.applyClient(operation.wrapped);
-  };
-
-  EditorClient.prototype.undo = function () {
-    var self = this;
-    if (!this.undoManager.canUndo()) { return; }
-    this.undoManager.performUndo(function (o) { self.applyUnredo(o); });
-  };
-
-  EditorClient.prototype.redo = function () {
-    var self = this;
-    if (!this.undoManager.canRedo()) { return; }
-    this.undoManager.performRedo(function (o) { self.applyUnredo(o); });
-  };
-
-  EditorClient.prototype.onChange = function (textOperation, inverse) {
-    var cursorBefore = this.cursor;
-    this.updateCursor();
-
-    var compose = this.undoManager.undoStack.length > 0 &&
-      inverse.shouldBeComposedWithInverted(last(this.undoManager.undoStack).wrapped);
-    var inverseMeta = new SelfMeta(this.cursor, cursorBefore);
-    this.undoManager.add(new WrappedOperation(inverse, inverseMeta), compose);
-    this.applyClient(textOperation);
-  };
-
-  EditorClient.prototype.updateCursor = function () {
-    this.cursor = this.editorAdapter.getCursor();
-  };
-
-  EditorClient.prototype.onCursorActivity = function () {
-    var oldCursor = this.cursor;
-    this.updateCursor();
-    if (!this.focused || oldCursor && this.cursor.equals(oldCursor)) { return; }
-    this.sendCursor(this.cursor);
-  };
-
-  EditorClient.prototype.onBlur = function () {
-    this.cursor = null;
-    this.sendCursor(null);
-    this.focused = false;
-  };
-
-  EditorClient.prototype.onFocus = function () {
-    this.focused = true;
-    this.onCursorActivity();
-  };
-
-  EditorClient.prototype.sendCursor = function (cursor) {
-    if (this.state instanceof Client.AwaitingWithBuffer) { return; }
-    this.serverAdapter.sendCursor(cursor);
-  };
-
-  EditorClient.prototype.sendOperation = function (operation) {
-    this.serverAdapter.sendOperation(operation);
-    this.emitStatus();
-  };
-
-  EditorClient.prototype.applyOperation = function (operation) {
-    this.editorAdapter.applyOperation(operation);
-    this.updateCursor();
-    this.undoManager.transform(new WrappedOperation(operation, null));
-  };
-
-  EditorClient.prototype.emitStatus = function() {
-    var self = this;
-    setTimeout(function() {
-      self.trigger('synced', self.state instanceof Client.Synchronized);
-    }, 0);
-  };
-
-  // Set Const.prototype.__proto__ to Super.prototype
-  function inherit (Const, Super) {
-    function F () {}
-    F.prototype = Super.prototype;
-    Const.prototype = new F();
-    Const.prototype.constructor = Const;
+    var client = this.clients[clientId]
+    if (client) {
+      return client
+    }
+    return (this.clients[clientId] = new OtherClient(clientId, this.editorAdapter))
   }
 
-  function last (arr) { return arr[arr.length - 1]; }
+  EditorClient.prototype.applyUnredo = function (operation) {
+    this.undoManager.add(this.editorAdapter.invertOperation(operation))
+    this.editorAdapter.applyOperation(operation.wrapped)
+    this.cursor = operation.meta.cursorAfter
+    if (this.cursor) this.editorAdapter.setCursor(this.cursor)
+    this.applyClient(operation.wrapped)
+  }
 
-  return EditorClient;
-}());
+  EditorClient.prototype.undo = function () {
+    var self = this
+    if (!this.undoManager.canUndo()) {
+      return
+    }
+    this.undoManager.performUndo(function (o) {
+      self.applyUnredo(o)
+    })
+  }
 
-firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced']);
+  EditorClient.prototype.redo = function () {
+    var self = this
+    if (!this.undoManager.canRedo()) {
+      return
+    }
+    this.undoManager.performRedo(function (o) {
+      self.applyUnredo(o)
+    })
+  }
+
+  EditorClient.prototype.onChange = function (textOperation, inverse) {
+    var cursorBefore = this.cursor
+    this.updateCursor()
+
+    var compose =
+      this.undoManager.undoStack.length > 0 &&
+      inverse.shouldBeComposedWithInverted(last(this.undoManager.undoStack).wrapped)
+    var inverseMeta = new SelfMeta(this.cursor, cursorBefore)
+    this.undoManager.add(new WrappedOperation(inverse, inverseMeta), compose)
+    this.applyClient(textOperation)
+  }
+
+  EditorClient.prototype.updateCursor = function () {
+    this.cursor = this.editorAdapter.getCursor()
+  }
+
+  EditorClient.prototype.onCursorActivity = function () {
+    var oldCursor = this.cursor
+    this.updateCursor()
+    if (!this.focused || (oldCursor && this.cursor.equals(oldCursor))) {
+      return
+    }
+    this.sendCursor(this.cursor)
+  }
+
+  EditorClient.prototype.onBlur = function () {
+    this.cursor = null
+    this.sendCursor(null)
+    this.focused = false
+  }
+
+  EditorClient.prototype.onFocus = function () {
+    this.focused = true
+    this.onCursorActivity()
+  }
+
+  EditorClient.prototype.sendCursor = function (cursor) {
+    if (this.state instanceof Client.AwaitingWithBuffer) {
+      return
+    }
+    this.serverAdapter.sendCursor(cursor)
+  }
+
+  EditorClient.prototype.sendOperation = function (operation) {
+    this.serverAdapter.sendOperation(operation)
+    this.emitStatus()
+  }
+
+  EditorClient.prototype.applyOperation = function (operation) {
+    this.editorAdapter.applyOperation(operation)
+    this.updateCursor()
+    this.undoManager.transform(new WrappedOperation(operation, null))
+  }
+
+  EditorClient.prototype.emitStatus = function () {
+    var self = this
+    setTimeout(function () {
+      self.trigger('synced', self.state instanceof Client.Synchronized)
+    }, 0)
+  }
+
+  // Set Const.prototype.__proto__ to Super.prototype
+  function inherit(Const, Super) {
+    function F() {}
+    F.prototype = Super.prototype
+    Const.prototype = new F()
+    Const.prototype.constructor = Const
+  }
+
+  function last(arr) {
+    return arr[arr.length - 1]
+  }
+
+  return EditorClient
+})()
+
+firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced'])

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -148,6 +148,9 @@ firepad.Firepad = (function (global) {
     this.client_.on('synced', function (isSynced) {
       self.trigger('synced', isSynced)
     })
+    this.client_.on('error', function (e) {
+      self.trigger('error', e)
+    })
 
     // Hack for IE8 to make font icons work more reliably.
     // http://stackoverflow.com/questions/9809351/ie8-css-font-face-fonts-only-working-for-before-content-on-over-and-sometimes

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -1,569 +1,612 @@
-var firepad = firepad || { };
+var firepad = firepad || {}
 
-firepad.Firepad = (function(global) {
+firepad.Firepad = (function (global) {
   if (!firepad.RichTextCodeMirrorAdapter) {
-    throw new Error("Oops! It looks like you're trying to include lib/firepad.js directly.  This is actually one of many source files that make up firepad.  You want dist/firepad.js instead.");
+    throw new Error(
+      "Oops! It looks like you're trying to include lib/firepad.js directly.  This is actually one of many source files that make up firepad.  You want dist/firepad.js instead."
+    )
   }
-  var RichTextCodeMirrorAdapter = firepad.RichTextCodeMirrorAdapter;
-  var RichTextCodeMirror = firepad.RichTextCodeMirror;
-  var RichTextToolbar = firepad.RichTextToolbar;
-  var ACEAdapter = firepad.ACEAdapter;
-  var MonacoAdapter = firepad.MonacoAdapter;
-  var FirebaseAdapter = firepad.FirebaseAdapter;
-  var EditorClient = firepad.EditorClient;
-  var EntityManager = firepad.EntityManager;
-  var ATTR = firepad.AttributeConstants;
-  var utils = firepad.utils;
-  var LIST_TYPE = firepad.LineFormatting.LIST_TYPE;
-  var CodeMirror = global.CodeMirror;
-  var ace = global.ace;
-  var monaco = global.monaco;
+  var RichTextCodeMirrorAdapter = firepad.RichTextCodeMirrorAdapter
+  var RichTextCodeMirror = firepad.RichTextCodeMirror
+  var RichTextToolbar = firepad.RichTextToolbar
+  var ACEAdapter = firepad.ACEAdapter
+  var MonacoAdapter = firepad.MonacoAdapter
+  var FirebaseAdapter = firepad.FirebaseAdapter
+  var EditorClient = firepad.EditorClient
+  var EntityManager = firepad.EntityManager
+  var ATTR = firepad.AttributeConstants
+  var utils = firepad.utils
+  var LIST_TYPE = firepad.LineFormatting.LIST_TYPE
+  var CodeMirror = global.CodeMirror
+  var ace = global.ace
+  var monaco = global.monaco
 
   function Firepad(ref, place, options) {
-    if (!(this instanceof Firepad)) { return new Firepad(ref, place, options); }
+    if (!(this instanceof Firepad)) {
+      return new Firepad(ref, place, options)
+    }
 
     if (!CodeMirror && !ace && !global.monaco) {
-      throw new Error('Couldn\'t find CodeMirror, ACE or Monaco.  Did you forget to include codemirror.js/ace.js or import monaco?');
+      throw new Error(
+        "Couldn't find CodeMirror, ACE or Monaco.  Did you forget to include codemirror.js/ace.js or import monaco?"
+      )
     }
 
-    this.zombie_ = false;
+    this.zombie_ = false
 
     if (CodeMirror && place instanceof CodeMirror) {
-      this.codeMirror_ = this.editor_ = place;
-      var curValue = this.codeMirror_.getValue();
+      this.codeMirror_ = this.editor_ = place
+      var curValue = this.codeMirror_.getValue()
       if (curValue !== '') {
-        throw new Error("Can't initialize Firepad with a CodeMirror instance that already contains text.");
+        throw new Error("Can't initialize Firepad with a CodeMirror instance that already contains text.")
       }
     } else if (ace && place && place.session instanceof ace.EditSession) {
-      this.ace_ = this.editor_ = place;
-      curValue = this.ace_.getValue();
+      this.ace_ = this.editor_ = place
+      curValue = this.ace_.getValue()
       if (curValue !== '') {
-        throw new Error("Can't initialize Firepad with an ACE instance that already contains text.");
+        throw new Error("Can't initialize Firepad with an ACE instance that already contains text.")
       }
     } else if (global.monaco && place && place instanceof global.monaco.constructor) {
-      monaco = global.monaco;
-      this.monaco_ = this.editor_ = place;
-      curValue = this.monaco_.getValue();
+      monaco = global.monaco
+      this.monaco_ = this.editor_ = place
+      curValue = this.monaco_.getValue()
       if (curValue !== '') {
-        throw new Error("Can't initialize Firepad with a Monaco instance that already contains text.");
+        throw new Error("Can't initialize Firepad with a Monaco instance that already contains text.")
       }
     } else {
-      this.codeMirror_ = this.editor_ = new CodeMirror(place);
+      this.codeMirror_ = this.editor_ = new CodeMirror(place)
     }
 
-    var editorWrapper;
+    var editorWrapper
     if (this.codeMirror_) {
-      editorWrapper = this.codeMirror_.getWrapperElement();
+      editorWrapper = this.codeMirror_.getWrapperElement()
     } else if (this.ace_) {
-      editorWrapper = this.ace_.container;
+      editorWrapper = this.ace_.container
     } else {
       editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
-    if (this.monaco_ != null) { // Do not create a wrapper for monaco
+    if (this.monaco_ != null) {
+      // Do not create a wrapper for monaco
       this.firepadWrapper_ = editorWrapper
     } else {
-      this.firepadWrapper_ = utils.elt("div", null, { 'class': 'firepad' });
-      editorWrapper.parentNode.replaceChild(this.firepadWrapper_, editorWrapper);
-      this.firepadWrapper_.appendChild(editorWrapper);
+      this.firepadWrapper_ = utils.elt('div', null, { class: 'firepad' })
+      editorWrapper.parentNode.replaceChild(this.firepadWrapper_, editorWrapper)
+      this.firepadWrapper_.appendChild(editorWrapper)
     }
 
     // Provide an easy way to get the firepad instance associated with this CodeMirror instance.
-    this.editor_.firepad = this;
+    this.editor_.firepad = this
 
-    this.options_ = options || { };
+    this.options_ = options || {}
 
     if (this.getOption('richTextShortcuts', false)) {
       if (!CodeMirror.keyMap['richtext']) {
-        this.initializeKeyMap_();
+        this.initializeKeyMap_()
       }
-      this.codeMirror_.setOption('keyMap', 'richtext');
-      this.firepadWrapper_.className += ' firepad-richtext';
+      this.codeMirror_.setOption('keyMap', 'richtext')
+      this.firepadWrapper_.className += ' firepad-richtext'
     }
 
-    this.imageInsertionUI = this.getOption('imageInsertionUI', true);
+    this.imageInsertionUI = this.getOption('imageInsertionUI', true)
 
     if (this.getOption('richTextToolbar', false)) {
-      this.addToolbar_();
-      this.firepadWrapper_.className += ' firepad-richtext firepad-with-toolbar';
+      this.addToolbar_()
+      this.firepadWrapper_.className += ' firepad-richtext firepad-with-toolbar'
     }
 
     // Now that we've mucked with CodeMirror, refresh it.
-    if (this.codeMirror_)
-      this.codeMirror_.refresh();
+    if (this.codeMirror_) this.codeMirror_.refresh()
 
-    var userId = this.getOption('userId', ref.push().key);
-    var userColor = this.getOption('userColor', colorFromUserId(userId));
+    var userId = this.getOption('userId', ref.push().key)
+    var userColor = this.getOption('userColor', colorFromUserId(userId))
 
-    this.entityManager_ = new EntityManager();
+    this.entityManager_ = new EntityManager()
 
-    this.firebaseAdapter_ = new FirebaseAdapter(ref, userId, userColor);
+    this.firebaseAdapter_ = new FirebaseAdapter(ref, userId, userColor)
     if (this.codeMirror_) {
-      this.richTextCodeMirror_ = new RichTextCodeMirror(this.codeMirror_, this.entityManager_, { cssPrefix: 'firepad-' });
-      this.editorAdapter_ = new RichTextCodeMirrorAdapter(this.richTextCodeMirror_);
+      this.richTextCodeMirror_ = new RichTextCodeMirror(this.codeMirror_, this.entityManager_, {
+        cssPrefix: 'firepad-',
+      })
+      this.editorAdapter_ = new RichTextCodeMirrorAdapter(this.richTextCodeMirror_)
     } else if (this.ace_) {
-      this.editorAdapter_ = new ACEAdapter(this.ace_);
+      this.editorAdapter_ = new ACEAdapter(this.ace_)
     } else {
-      this.editorAdapter_ = new MonacoAdapter(this.monaco_);
+      this.editorAdapter_ = new MonacoAdapter(this.monaco_)
     }
-    this.client_ = new EditorClient(this.firebaseAdapter_, this.editorAdapter_);
+    this.client_ = new EditorClient(this.firebaseAdapter_, this.editorAdapter_)
 
-    var self = this;
-    this.firebaseAdapter_.on('cursor', function() {
-      self.trigger.apply(self, ['cursor'].concat([].slice.call(arguments)));
-    });
+    var self = this
+    this.firebaseAdapter_.on('cursor', function () {
+      self.trigger.apply(self, ['cursor'].concat([].slice.call(arguments)))
+    })
 
     if (this.codeMirror_) {
-      this.richTextCodeMirror_.on('newLine', function() {
-        self.trigger.apply(self, ['newLine'].concat([].slice.call(arguments)));
-      });
+      this.richTextCodeMirror_.on('newLine', function () {
+        self.trigger.apply(self, ['newLine'].concat([].slice.call(arguments)))
+      })
     }
 
-    this.firebaseAdapter_.on('ready', function() {
-      self.ready_ = true;
+    this.firebaseAdapter_.on('ready', function () {
+      self.ready_ = true
 
       if (this.ace_) {
-        this.editorAdapter_.grabDocumentState();
+        this.editorAdapter_.grabDocumentState()
       }
       if (this.monaco_) {
-        this.editorAdapter_.grabDocumentState();
+        this.editorAdapter_.grabDocumentState()
       }
 
-      var defaultText = self.getOption('defaultText', null);
+      var defaultText = self.getOption('defaultText', null)
       if (defaultText && self.isHistoryEmpty()) {
-        self.setText(defaultText);
+        self.setText(defaultText)
       }
 
-      self.trigger('ready');
-    });
+      self.trigger('ready')
+    })
 
-    this.client_.on('synced', function(isSynced) { self.trigger('synced', isSynced)} );
+    this.client_.on('synced', function (isSynced) {
+      self.trigger('synced', isSynced)
+    })
 
     // Hack for IE8 to make font icons work more reliably.
     // http://stackoverflow.com/questions/9809351/ie8-css-font-face-fonts-only-working-for-before-content-on-over-and-sometimes
     if (navigator.appName == 'Microsoft Internet Explorer' && navigator.userAgent.match(/MSIE 8\./)) {
-      window.onload = function() {
+      window.onload = function () {
         var head = document.getElementsByTagName('head')[0],
-          style = document.createElement('style');
-        style.type = 'text/css';
-        style.styleSheet.cssText = ':before,:after{content:none !important;}';
-        head.appendChild(style);
-        setTimeout(function() {
-          head.removeChild(style);
-        }, 0);
-      };
+          style = document.createElement('style')
+        style.type = 'text/css'
+        style.styleSheet.cssText = ':before,:after{content:none !important;}'
+        head.appendChild(style)
+        setTimeout(function () {
+          head.removeChild(style)
+        }, 0)
+      }
     }
   }
-  utils.makeEventEmitter(Firepad);
+  utils.makeEventEmitter(Firepad)
 
   // For readability, these are the primary "constructors", even though right now they're just aliases for Firepad.
-  Firepad.fromCodeMirror = Firepad;
-  Firepad.fromACE = Firepad;
-  Firepad.fromMonaco = Firepad;
+  Firepad.fromCodeMirror = Firepad
+  Firepad.fromACE = Firepad
+  Firepad.fromMonaco = Firepad
 
-
-  Firepad.prototype.dispose = function() {
-    this.zombie_ = true; // We've been disposed.  No longer valid to do anything.
+  Firepad.prototype.dispose = function () {
+    this.zombie_ = true // We've been disposed.  No longer valid to do anything.
 
     // Unwrap the editor.
     // var editorWrapper = this.codeMirror_ ? this.codeMirror_.getWrapperElement() : this.ace_.container;
     if (this.codeMirror_) {
-        editorWrapper = this.codeMirror_.getWrapperElement();
+      editorWrapper = this.codeMirror_.getWrapperElement()
     } else if (this.ace_) {
-        editorWrapper = this.ace_.container;
+      editorWrapper = this.ace_.container
     } else {
-        editorWrapper = this.monaco_.getDomNode().parentNode
+      editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
     // For monaco we don't create a wrapper
     if (this.firepadWrapper_ !== editorWrapper) {
-      this.firepadWrapper_.removeChild(editorWrapper);
-      this.firepadWrapper_.parentNode.replaceChild(editorWrapper, this.firepadWrapper_);
+      this.firepadWrapper_.removeChild(editorWrapper)
+      this.firepadWrapper_.parentNode.replaceChild(editorWrapper, this.firepadWrapper_)
     }
 
-    this.editor_.firepad = null;
+    this.editor_.firepad = null
 
     if (this.codeMirror_ && this.codeMirror_.getOption('keyMap') === 'richtext') {
-      this.codeMirror_.setOption('keyMap', 'default');
+      this.codeMirror_.setOption('keyMap', 'default')
     }
 
-    this.firebaseAdapter_.dispose();
-    this.editorAdapter_.detach();
-    if (this.richTextCodeMirror_)
-      this.richTextCodeMirror_.detach();
-  };
+    this.firebaseAdapter_.dispose()
+    this.editorAdapter_.detach()
+    if (this.richTextCodeMirror_) this.richTextCodeMirror_.detach()
+  }
 
-  Firepad.prototype.setUserId = function(userId) {
-    this.firebaseAdapter_.setUserId(userId);
-  };
+  Firepad.prototype.setUserId = function (userId) {
+    this.firebaseAdapter_.setUserId(userId)
+  }
 
-  Firepad.prototype.setUserColor = function(color) {
-    this.firebaseAdapter_.setColor(color);
-  };
+  Firepad.prototype.setUserColor = function (color) {
+    this.firebaseAdapter_.setColor(color)
+  }
 
-  Firepad.prototype.getText = function() {
-    this.assertReady_('getText');
-    if (this.codeMirror_)
-      return this.richTextCodeMirror_.getText();
-    else if (this.ace_)
-      return this.ace_.getSession().getDocument().getValue();
-    else
-      return this.monaco_.getModel().getValue();
-  };
+  Firepad.prototype.getText = function () {
+    this.assertReady_('getText')
+    if (this.codeMirror_) return this.richTextCodeMirror_.getText()
+    else if (this.ace_) return this.ace_.getSession().getDocument().getValue()
+    else return this.monaco_.getModel().getValue()
+  }
 
-  Firepad.prototype.setText = function(textPieces) {
-      this.assertReady_('setText');
+  Firepad.prototype.setText = function (textPieces) {
+    this.assertReady_('setText')
     if (this.monaco_) {
-      return this.monaco_.getModel().setValue(textPieces);
+      return this.monaco_.getModel().setValue(textPieces)
     } else if (this.ace_) {
-      return this.ace_.getSession().getDocument().setValue(textPieces);
+      return this.ace_.getSession().getDocument().setValue(textPieces)
     } else {
       // HACK: Hide CodeMirror during setText to prevent lots of extra renders.
-      this.codeMirror_.getWrapperElement().style.display = "none";
-      this.codeMirror_.setValue("");
-      this.insertText(0, textPieces);
-      this.codeMirror_.getWrapperElement().style.display = "";
-      this.codeMirror_.refresh();
+      this.codeMirror_.getWrapperElement().style.display = 'none'
+      this.codeMirror_.setValue('')
+      this.insertText(0, textPieces)
+      this.codeMirror_.getWrapperElement().style.display = ''
+      this.codeMirror_.refresh()
     }
-    this.editorAdapter_.setCursor({position: 0, selectionEnd: 0});
-  };
+    this.editorAdapter_.setCursor({ position: 0, selectionEnd: 0 })
+  }
 
-  Firepad.prototype.insertTextAtCursor = function(textPieces) {
-    this.insertText(this.codeMirror_.indexFromPos(this.codeMirror_.getCursor()), textPieces);
-  };
+  Firepad.prototype.insertTextAtCursor = function (textPieces) {
+    this.insertText(this.codeMirror_.indexFromPos(this.codeMirror_.getCursor()), textPieces)
+  }
 
-  Firepad.prototype.insertText = function(index, textPieces) {
-    utils.assert(!this.ace_, "Not supported for ace yet.");
-    utils.assert(!this.monaco_, "Not supported for monaco yet.");
-    this.assertReady_('insertText');
+  Firepad.prototype.insertText = function (index, textPieces) {
+    utils.assert(!this.ace_, 'Not supported for ace yet.')
+    utils.assert(!this.monaco_, 'Not supported for monaco yet.')
+    this.assertReady_('insertText')
 
     // Wrap it in an array if it's not already.
-    if(Object.prototype.toString.call(textPieces) !== '[object Array]') {
-      textPieces = [textPieces];
+    if (Object.prototype.toString.call(textPieces) !== '[object Array]') {
+      textPieces = [textPieces]
     }
 
-    var self = this;
-    self.codeMirror_.operation(function() {
+    var self = this
+    self.codeMirror_.operation(function () {
       // HACK: We should check if we're actually at the beginning of a line; but checking for index == 0 is sufficient
       // for the setText() case.
-      var atNewLine = index === 0;
-      var inserts = firepad.textPiecesToInserts(atNewLine, textPieces);
+      var atNewLine = index === 0
+      var inserts = firepad.textPiecesToInserts(atNewLine, textPieces)
 
       for (var i = 0; i < inserts.length; i++) {
-        var string     = inserts[i].string;
-        var attributes = inserts[i].attributes;
-        self.richTextCodeMirror_.insertText(index, string, attributes);
-        index += string.length;
+        var string = inserts[i].string
+        var attributes = inserts[i].attributes
+        self.richTextCodeMirror_.insertText(index, string, attributes)
+        index += string.length
       }
-    });
-  };
+    })
+  }
 
-  Firepad.prototype.getOperationForSpan = function(start, end) {
-    var text = this.richTextCodeMirror_.getRange(start, end);
-    var spans = this.richTextCodeMirror_.getAttributeSpans(start, end);
-    var pos = 0;
-    var op = new firepad.TextOperation();
-    for(var i = 0; i < spans.length; i++) {
-      op.insert(text.substr(pos, spans[i].length), spans[i].attributes);
-      pos += spans[i].length;
+  Firepad.prototype.getOperationForSpan = function (start, end) {
+    var text = this.richTextCodeMirror_.getRange(start, end)
+    var spans = this.richTextCodeMirror_.getAttributeSpans(start, end)
+    var pos = 0
+    var op = new firepad.TextOperation()
+    for (var i = 0; i < spans.length; i++) {
+      op.insert(text.substr(pos, spans[i].length), spans[i].attributes)
+      pos += spans[i].length
     }
-    return op;
-  };
+    return op
+  }
 
-  Firepad.prototype.getHtml = function() {
-    return this.getHtmlFromRange(null, null);
-  };
+  Firepad.prototype.getHtml = function () {
+    return this.getHtmlFromRange(null, null)
+  }
 
-  Firepad.prototype.getHtmlFromSelection = function() {
-    var startPos = this.codeMirror_.getCursor('start'), endPos = this.codeMirror_.getCursor('end');
-    var startIndex = this.codeMirror_.indexFromPos(startPos), endIndex = this.codeMirror_.indexFromPos(endPos);
-    return this.getHtmlFromRange(startIndex, endIndex);
-  };
+  Firepad.prototype.getHtmlFromSelection = function () {
+    var startPos = this.codeMirror_.getCursor('start'),
+      endPos = this.codeMirror_.getCursor('end')
+    var startIndex = this.codeMirror_.indexFromPos(startPos),
+      endIndex = this.codeMirror_.indexFromPos(endPos)
+    return this.getHtmlFromRange(startIndex, endIndex)
+  }
 
-  Firepad.prototype.getHtmlFromRange = function(start, end) {
-    this.assertReady_('getHtmlFromRange');
-    var doc = (start != null && end != null) ?
-      this.getOperationForSpan(start, end) :
-      this.getOperationForSpan(0, this.codeMirror_.getValue().length);
-    return firepad.SerializeHtml(doc, this.entityManager_);
-  };
+  Firepad.prototype.getHtmlFromRange = function (start, end) {
+    this.assertReady_('getHtmlFromRange')
+    var doc =
+      start != null && end != null
+        ? this.getOperationForSpan(start, end)
+        : this.getOperationForSpan(0, this.codeMirror_.getValue().length)
+    return firepad.SerializeHtml(doc, this.entityManager_)
+  }
 
   Firepad.prototype.insertHtml = function (index, html) {
-    var lines = firepad.ParseHtml(html, this.entityManager_);
-    this.insertText(index, lines);
-  };
+    var lines = firepad.ParseHtml(html, this.entityManager_)
+    this.insertText(index, lines)
+  }
 
   Firepad.prototype.insertHtmlAtCursor = function (html) {
-    this.insertHtml(this.codeMirror_.indexFromPos(this.codeMirror_.getCursor()), html);
-  };
+    this.insertHtml(this.codeMirror_.indexFromPos(this.codeMirror_.getCursor()), html)
+  }
 
   Firepad.prototype.setHtml = function (html) {
-    var lines = firepad.ParseHtml(html, this.entityManager_);
-    this.setText(lines);
-  };
+    var lines = firepad.ParseHtml(html, this.entityManager_)
+    this.setText(lines)
+  }
 
-  Firepad.prototype.isHistoryEmpty = function() {
-    this.assertReady_('isHistoryEmpty');
-    return this.firebaseAdapter_.isHistoryEmpty();
-  };
+  Firepad.prototype.isHistoryEmpty = function () {
+    this.assertReady_('isHistoryEmpty')
+    return this.firebaseAdapter_.isHistoryEmpty()
+  }
 
-  Firepad.prototype.bold = function() {
-    this.richTextCodeMirror_.toggleAttribute(ATTR.BOLD);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.bold = function () {
+    this.richTextCodeMirror_.toggleAttribute(ATTR.BOLD)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.italic = function() {
-    this.richTextCodeMirror_.toggleAttribute(ATTR.ITALIC);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.italic = function () {
+    this.richTextCodeMirror_.toggleAttribute(ATTR.ITALIC)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.underline = function() {
-    this.richTextCodeMirror_.toggleAttribute(ATTR.UNDERLINE);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.underline = function () {
+    this.richTextCodeMirror_.toggleAttribute(ATTR.UNDERLINE)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.strike = function() {
-    this.richTextCodeMirror_.toggleAttribute(ATTR.STRIKE);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.strike = function () {
+    this.richTextCodeMirror_.toggleAttribute(ATTR.STRIKE)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.fontSize = function(size) {
-    this.richTextCodeMirror_.setAttribute(ATTR.FONT_SIZE, size);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.fontSize = function (size) {
+    this.richTextCodeMirror_.setAttribute(ATTR.FONT_SIZE, size)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.font = function(font) {
-    this.richTextCodeMirror_.setAttribute(ATTR.FONT, font);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.font = function (font) {
+    this.richTextCodeMirror_.setAttribute(ATTR.FONT, font)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.color = function(color) {
-    this.richTextCodeMirror_.setAttribute(ATTR.COLOR, color);
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.color = function (color) {
+    this.richTextCodeMirror_.setAttribute(ATTR.COLOR, color)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.highlight = function() {
-    this.richTextCodeMirror_.toggleAttribute(ATTR.BACKGROUND_COLOR, 'rgba(255,255,0,.65)');
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.highlight = function () {
+    this.richTextCodeMirror_.toggleAttribute(ATTR.BACKGROUND_COLOR, 'rgba(255,255,0,.65)')
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.align = function(alignment) {
+  Firepad.prototype.align = function (alignment) {
     if (alignment !== 'left' && alignment !== 'center' && alignment !== 'right') {
-      throw new Error('align() must be passed "left", "center", or "right".');
+      throw new Error('align() must be passed "left", "center", or "right".')
     }
-    this.richTextCodeMirror_.setLineAttribute(ATTR.LINE_ALIGN, alignment);
-    this.codeMirror_.focus();
-  };
+    this.richTextCodeMirror_.setLineAttribute(ATTR.LINE_ALIGN, alignment)
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.orderedList = function() {
-    this.richTextCodeMirror_.toggleLineAttribute(ATTR.LIST_TYPE, 'o');
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.orderedList = function () {
+    this.richTextCodeMirror_.toggleLineAttribute(ATTR.LIST_TYPE, 'o')
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.unorderedList = function() {
-    this.richTextCodeMirror_.toggleLineAttribute(ATTR.LIST_TYPE, 'u');
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.unorderedList = function () {
+    this.richTextCodeMirror_.toggleLineAttribute(ATTR.LIST_TYPE, 'u')
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.todo = function() {
-    this.richTextCodeMirror_.toggleTodo();
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.todo = function () {
+    this.richTextCodeMirror_.toggleTodo()
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.newline = function() {
-    this.richTextCodeMirror_.newline();
-  };
+  Firepad.prototype.newline = function () {
+    this.richTextCodeMirror_.newline()
+  }
 
-  Firepad.prototype.deleteLeft = function() {
-    this.richTextCodeMirror_.deleteLeft();
-  };
+  Firepad.prototype.deleteLeft = function () {
+    this.richTextCodeMirror_.deleteLeft()
+  }
 
-  Firepad.prototype.deleteRight = function() {
-    this.richTextCodeMirror_.deleteRight();
-  };
+  Firepad.prototype.deleteRight = function () {
+    this.richTextCodeMirror_.deleteRight()
+  }
 
-  Firepad.prototype.indent = function() {
-    this.richTextCodeMirror_.indent();
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.indent = function () {
+    this.richTextCodeMirror_.indent()
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.unindent = function() {
-    this.richTextCodeMirror_.unindent();
-    this.codeMirror_.focus();
-  };
+  Firepad.prototype.unindent = function () {
+    this.richTextCodeMirror_.unindent()
+    this.codeMirror_.focus()
+  }
 
-  Firepad.prototype.undo = function() {
-    this.codeMirror_.undo();
-  };
+  Firepad.prototype.undo = function () {
+    this.codeMirror_.undo()
+  }
 
-  Firepad.prototype.redo = function() {
-    this.codeMirror_.redo();
-  };
+  Firepad.prototype.redo = function () {
+    this.codeMirror_.redo()
+  }
 
-  Firepad.prototype.insertEntity = function(type, info, origin) {
-    this.richTextCodeMirror_.insertEntityAtCursor(type, info, origin);
-  };
+  Firepad.prototype.insertEntity = function (type, info, origin) {
+    this.richTextCodeMirror_.insertEntityAtCursor(type, info, origin)
+  }
 
-  Firepad.prototype.insertEntityAt = function(index, type, info, origin) {
-    this.richTextCodeMirror_.insertEntityAt(index, type, info, origin);
-  };
+  Firepad.prototype.insertEntityAt = function (index, type, info, origin) {
+    this.richTextCodeMirror_.insertEntityAt(index, type, info, origin)
+  }
 
-  Firepad.prototype.registerEntity = function(type, options) {
-    this.entityManager_.register(type, options);
-  };
+  Firepad.prototype.registerEntity = function (type, options) {
+    this.entityManager_.register(type, options)
+  }
 
-  Firepad.prototype.getOption = function(option, def) {
-    return (option in this.options_) ? this.options_[option] : def;
-  };
+  Firepad.prototype.getOption = function (option, def) {
+    return option in this.options_ ? this.options_[option] : def
+  }
 
-  Firepad.prototype.assertReady_ = function(funcName) {
+  Firepad.prototype.assertReady_ = function (funcName) {
     if (!this.ready_) {
-      throw new Error('You must wait for the "ready" event before calling ' + funcName + '.');
+      throw new Error('You must wait for the "ready" event before calling ' + funcName + '.')
     }
     if (this.zombie_) {
-      throw new Error('You can\'t use a Firepad after calling dispose()!  [called ' + funcName + ']');
+      throw new Error("You can't use a Firepad after calling dispose()!  [called " + funcName + ']')
     }
-  };
+  }
 
-  Firepad.prototype.makeImageDialog_ = function() {
-    this.makeDialog_('img', 'Insert image url');
-  };
+  Firepad.prototype.makeImageDialog_ = function () {
+    this.makeDialog_('img', 'Insert image url')
+  }
 
-  Firepad.prototype.makeDialog_ = function(id, placeholder) {
-   var self = this;
+  Firepad.prototype.makeDialog_ = function (id, placeholder) {
+    var self = this
 
-   var hideDialog = function() {
-     var dialog = document.getElementById('overlay');
-     dialog.style.visibility = "hidden";
-     self.firepadWrapper_.removeChild(dialog);
-   };
+    var hideDialog = function () {
+      var dialog = document.getElementById('overlay')
+      dialog.style.visibility = 'hidden'
+      self.firepadWrapper_.removeChild(dialog)
+    }
 
-   var cb = function() {
-     var dialog = document.getElementById('overlay');
-     dialog.style.visibility = "hidden";
-     var src = document.getElementById(id).value;
-     if (src !== null)
-       self.insertEntity(id, { 'src': src });
-     self.firepadWrapper_.removeChild(dialog);
-   };
+    var cb = function () {
+      var dialog = document.getElementById('overlay')
+      dialog.style.visibility = 'hidden'
+      var src = document.getElementById(id).value
+      if (src !== null) self.insertEntity(id, { src: src })
+      self.firepadWrapper_.removeChild(dialog)
+    }
 
-   var input = utils.elt('input', null, { 'class':'firepad-dialog-input', 'id':id, 'type':'text', 'placeholder':placeholder, 'autofocus':'autofocus' });
+    var input = utils.elt('input', null, {
+      class: 'firepad-dialog-input',
+      id: id,
+      type: 'text',
+      placeholder: placeholder,
+      autofocus: 'autofocus',
+    })
 
-   var submit = utils.elt('a', 'Submit', { 'class': 'firepad-btn', 'id':'submitbtn' });
-   utils.on(submit, 'click', utils.stopEventAnd(cb));
+    var submit = utils.elt('a', 'Submit', { class: 'firepad-btn', id: 'submitbtn' })
+    utils.on(submit, 'click', utils.stopEventAnd(cb))
 
-   var cancel = utils.elt('a', 'Cancel', { 'class': 'firepad-btn' });
-   utils.on(cancel, 'click', utils.stopEventAnd(hideDialog));
+    var cancel = utils.elt('a', 'Cancel', { class: 'firepad-btn' })
+    utils.on(cancel, 'click', utils.stopEventAnd(hideDialog))
 
-   var buttonsdiv = utils.elt('div', [submit, cancel], { 'class':'firepad-btn-group' });
+    var buttonsdiv = utils.elt('div', [submit, cancel], { class: 'firepad-btn-group' })
 
-   var div = utils.elt('div', [input, buttonsdiv], { 'class':'firepad-dialog-div' });
-   var dialog = utils.elt('div', [div], { 'class': 'firepad-dialog', id:'overlay' });
+    var div = utils.elt('div', [input, buttonsdiv], { class: 'firepad-dialog-div' })
+    var dialog = utils.elt('div', [div], { class: 'firepad-dialog', id: 'overlay' })
 
-   this.firepadWrapper_.appendChild(dialog);
-  };
+    this.firepadWrapper_.appendChild(dialog)
+  }
 
-  Firepad.prototype.addToolbar_ = function() {
-    this.toolbar = new RichTextToolbar(this.imageInsertionUI);
+  Firepad.prototype.addToolbar_ = function () {
+    this.toolbar = new RichTextToolbar(this.imageInsertionUI)
 
-    this.toolbar.on('undo', this.undo, this);
-    this.toolbar.on('redo', this.redo, this);
-    this.toolbar.on('bold', this.bold, this);
-    this.toolbar.on('italic', this.italic, this);
-    this.toolbar.on('underline', this.underline, this);
-    this.toolbar.on('strike', this.strike, this);
-    this.toolbar.on('font-size', this.fontSize, this);
-    this.toolbar.on('font', this.font, this);
-    this.toolbar.on('color', this.color, this);
-    this.toolbar.on('left', function() { this.align('left')}, this);
-    this.toolbar.on('center', function() { this.align('center')}, this);
-    this.toolbar.on('right', function() { this.align('right')}, this);
-    this.toolbar.on('ordered-list', this.orderedList, this);
-    this.toolbar.on('unordered-list', this.unorderedList, this);
-    this.toolbar.on('todo-list', this.todo, this);
-    this.toolbar.on('indent-increase', this.indent, this);
-    this.toolbar.on('indent-decrease', this.unindent, this);
-    this.toolbar.on('insert-image', this.makeImageDialog_, this);
+    this.toolbar.on('undo', this.undo, this)
+    this.toolbar.on('redo', this.redo, this)
+    this.toolbar.on('bold', this.bold, this)
+    this.toolbar.on('italic', this.italic, this)
+    this.toolbar.on('underline', this.underline, this)
+    this.toolbar.on('strike', this.strike, this)
+    this.toolbar.on('font-size', this.fontSize, this)
+    this.toolbar.on('font', this.font, this)
+    this.toolbar.on('color', this.color, this)
+    this.toolbar.on(
+      'left',
+      function () {
+        this.align('left')
+      },
+      this
+    )
+    this.toolbar.on(
+      'center',
+      function () {
+        this.align('center')
+      },
+      this
+    )
+    this.toolbar.on(
+      'right',
+      function () {
+        this.align('right')
+      },
+      this
+    )
+    this.toolbar.on('ordered-list', this.orderedList, this)
+    this.toolbar.on('unordered-list', this.unorderedList, this)
+    this.toolbar.on('todo-list', this.todo, this)
+    this.toolbar.on('indent-increase', this.indent, this)
+    this.toolbar.on('indent-decrease', this.unindent, this)
+    this.toolbar.on('insert-image', this.makeImageDialog_, this)
 
-    this.firepadWrapper_.insertBefore(this.toolbar.element(), this.firepadWrapper_.firstChild);
-  };
+    this.firepadWrapper_.insertBefore(this.toolbar.element(), this.firepadWrapper_.firstChild)
+  }
 
-  Firepad.prototype.initializeKeyMap_ = function() {
+  Firepad.prototype.initializeKeyMap_ = function () {
     function binder(fn) {
-      return function(cm) {
+      return function (cm) {
         // HACK: CodeMirror will often call our key handlers within a cm.operation(), and that
         // can mess us up (we rely on events being triggered synchronously when we make CodeMirror
         // edits).  So to escape any cm.operation(), we do a setTimeout.
-        setTimeout(function() {
-          fn.call(cm.firepad);
-        }, 0);
+        setTimeout(function () {
+          fn.call(cm.firepad)
+        }, 0)
       }
     }
 
-    CodeMirror.keyMap["richtext"] = {
-      "Ctrl-B": binder(this.bold),
-      "Cmd-B": binder(this.bold),
-      "Ctrl-I": binder(this.italic),
-      "Cmd-I": binder(this.italic),
-      "Ctrl-U": binder(this.underline),
-      "Cmd-U": binder(this.underline),
-      "Ctrl-H": binder(this.highlight),
-      "Cmd-H": binder(this.highlight),
-      "Enter": binder(this.newline),
-      "Delete": binder(this.deleteRight),
-      "Backspace": binder(this.deleteLeft),
-      "Tab": binder(this.indent),
-      "Shift-Tab": binder(this.unindent),
-      fallthrough: ['default']
-    };
-  };
+    CodeMirror.keyMap['richtext'] = {
+      'Ctrl-B': binder(this.bold),
+      'Cmd-B': binder(this.bold),
+      'Ctrl-I': binder(this.italic),
+      'Cmd-I': binder(this.italic),
+      'Ctrl-U': binder(this.underline),
+      'Cmd-U': binder(this.underline),
+      'Ctrl-H': binder(this.highlight),
+      'Cmd-H': binder(this.highlight),
+      Enter: binder(this.newline),
+      Delete: binder(this.deleteRight),
+      Backspace: binder(this.deleteLeft),
+      Tab: binder(this.indent),
+      'Shift-Tab': binder(this.unindent),
+      fallthrough: ['default'],
+    }
+  }
 
-  function colorFromUserId (userId) {
-    var a = 1;
+  function colorFromUserId(userId) {
+    var a = 1
     for (var i = 0; i < userId.length; i++) {
-      a = 17 * (a+userId.charCodeAt(i)) % 360;
+      a = (17 * (a + userId.charCodeAt(i))) % 360
     }
-    var hue = a/360;
+    var hue = a / 360
 
-    return hsl2hex(hue, 1, 0.75);
+    return hsl2hex(hue, 1, 0.75)
   }
 
-  function rgb2hex (r, g, b) {
-    function digits (n) {
-      var m = Math.round(255*n).toString(16);
-      return m.length === 1 ? '0'+m : m;
+  function rgb2hex(r, g, b) {
+    function digits(n) {
+      var m = Math.round(255 * n).toString(16)
+      return m.length === 1 ? '0' + m : m
     }
-    return '#' + digits(r) + digits(g) + digits(b);
+    return '#' + digits(r) + digits(g) + digits(b)
   }
 
-  function hsl2hex (h, s, l) {
-    if (s === 0) { return rgb2hex(l, l, l); }
-    var var2 = l < 0.5 ? l * (1+s) : (l+s) - (s*l);
-    var var1 = 2 * l - var2;
+  function hsl2hex(h, s, l) {
+    if (s === 0) {
+      return rgb2hex(l, l, l)
+    }
+    var var2 = l < 0.5 ? l * (1 + s) : l + s - s * l
+    var var1 = 2 * l - var2
     var hue2rgb = function (hue) {
-      if (hue < 0) { hue += 1; }
-      if (hue > 1) { hue -= 1; }
-      if (6*hue < 1) { return var1 + (var2-var1)*6*hue; }
-      if (2*hue < 1) { return var2; }
-      if (3*hue < 2) { return var1 + (var2-var1)*6*(2/3 - hue); }
-      return var1;
-    };
-    return rgb2hex(hue2rgb(h+1/3), hue2rgb(h), hue2rgb(h-1/3));
+      if (hue < 0) {
+        hue += 1
+      }
+      if (hue > 1) {
+        hue -= 1
+      }
+      if (6 * hue < 1) {
+        return var1 + (var2 - var1) * 6 * hue
+      }
+      if (2 * hue < 1) {
+        return var2
+      }
+      if (3 * hue < 2) {
+        return var1 + (var2 - var1) * 6 * (2 / 3 - hue)
+      }
+      return var1
+    }
+    return rgb2hex(hue2rgb(h + 1 / 3), hue2rgb(h), hue2rgb(h - 1 / 3))
   }
 
-  return Firepad;
-})(this);
+  return Firepad
+})(this)
 
 // Export Text classes
-firepad.Firepad.Formatting = firepad.Formatting;
-firepad.Firepad.Text = firepad.Text;
-firepad.Firepad.Entity = firepad.Entity;
-firepad.Firepad.LineFormatting = firepad.LineFormatting;
-firepad.Firepad.Line = firepad.Line;
-firepad.Firepad.TextOperation = firepad.TextOperation;
-firepad.Firepad.Headless = firepad.Headless;
+firepad.Firepad.Formatting = firepad.Formatting
+firepad.Firepad.Text = firepad.Text
+firepad.Firepad.Entity = firepad.Entity
+firepad.Firepad.LineFormatting = firepad.LineFormatting
+firepad.Firepad.Line = firepad.Line
+firepad.Firepad.TextOperation = firepad.TextOperation
+firepad.Firepad.Headless = firepad.Headless
 
 // Export adapters
-firepad.Firepad.RichTextCodeMirrorAdapter = firepad.RichTextCodeMirrorAdapter;
-firepad.Firepad.ACEAdapter = firepad.ACEAdapter;
-firepad.Firepad.MonacoAdapter = firepad.MonacoAdapter;
+firepad.Firepad.RichTextCodeMirrorAdapter = firepad.RichTextCodeMirrorAdapter
+firepad.Firepad.ACEAdapter = firepad.ACEAdapter
+firepad.Firepad.MonacoAdapter = firepad.MonacoAdapter

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderpad_io/firepad",
   "description": "Collaborative text editing powered by Firebase. As forked by Coderpad.io.",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
This updates Firepad to emit error events when an "invalid operation length" error occurs, so that we can log and use that error info in the Rails app. We could also add more error logs as we need them. This provides a nice way to listen for Firepad errors without doing something like listening on the global onerror event.

There were some auto-formatting changes here, so in the commits you'll a patter of `formatting commit -> actual update` for the files that were changed. It will likely be easier to review commit by commit for that reason.