### PR TITLE
fix(monaco): disable trimAutoWhitespace while editing

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -449,6 +449,10 @@ var MonacoAdapter = function () {
       this.ignoreChanges = true;
     }
 
+    /** Ensure whitespace is not automatically trimmed while executing edits */
+    var userWhitespaceSetting = this.monacoModel.getOptions().trimAutoWhitespace
+    this.monacoModel.updateOptions({ trimAutoWhitespace: false })
+
     /** Get Operations List */
     var opsList = operation.ops;
     var index = 0;
@@ -487,6 +491,9 @@ var MonacoAdapter = function () {
         }]);
       }
     });
+
+    /** Restore whitespace auto-trim setting */
+    this.monacoModel.updateOptions({ trimAutoWhitespace: userWhitespaceSetting })
 
     /** Update Editor Content and Reset Config */
     this.lastDocLines = this.monacoModel.getLinesContent();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderpad_io/firepad",
   "description": "Collaborative text editing powered by Firebase. As forked by Coderpad.io.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
This PR disables the `trimAutoWhitespace` model option while executing a series of operations on `monaco` editors.  Without this functionality, it is possible for two users to get out of sync due to edits that a remote user's editor applies when trimming whitespace.