### PR TITLE
Fix monaco adapter

### DIFF
--- a/examples/hammer.html
+++ b/examples/hammer.html
@@ -54,7 +54,7 @@
         lineWrapping: true,
         mode: 'markdown'
       });
-      var firepad = new Firepad(firepadRef, cm);
+      var firepad = new Firepad('CodeMirror', firepadRef, cm);
 
       var richText = window.location.href.indexOf('#rich') >= 0;
 

--- a/examples/monaco.html
+++ b/examples/monaco.html
@@ -50,7 +50,7 @@
                     language: 'javascript'
                 }
             );
-            Firepad.fromMonaco(firepadRef, editor);
+            Firepad.fromMonaco(firepadRef, editor.getModel(), {}, monaco);
         });
 
     }

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -42,7 +42,6 @@ firepad.EditorClient = (function () {
   }
 
   OtherClient.prototype.updateCursor = function (cursor) {
-    this.removeCursor()
     this.cursor = cursor
     this.mark = this.editorAdapter.setOtherCursor(cursor, this.color, this.id, this.name)
   }

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -185,7 +185,11 @@ firepad.EditorClient = (function () {
 
   EditorClient.prototype.onFocus = function () {
     this.focused = true
-    this.onCursorActivity()
+    // send it in a timeout because a focus is often followed by a cursor move
+    // and we don't want to send the previous cursor location when the editor is focused
+    setTimeout(() => {
+      this.onCursorActivity()
+    })
   }
 
   EditorClient.prototype.sendCursor = function (cursor) {

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -37,10 +37,14 @@ firepad.EditorClient = (function () {
     this.color = color
   }
 
+  OtherClient.prototype.setName = function (name) {
+    this.name = name
+  }
+
   OtherClient.prototype.updateCursor = function (cursor) {
     this.removeCursor()
     this.cursor = cursor
-    this.mark = this.editorAdapter.setOtherCursor(cursor, this.color, this.id)
+    this.mark = this.editorAdapter.setOtherCursor(cursor, this.color, this.id, this.name)
   }
 
   OtherClient.prototype.removeCursor = function () {
@@ -95,13 +99,14 @@ firepad.EditorClient = (function () {
       operation: function (operation) {
         self.applyServer(operation)
       },
-      cursor: function (clientId, cursor, color) {
+      cursor: function (clientId, cursor, color, name) {
         if (self.serverAdapter.userId_ === clientId || !(self.state instanceof Client.Synchronized)) {
           return
         }
         var client = self.getClientObject(clientId)
         if (cursor) {
           if (color) client.setColor(color)
+          if (name) client.setName(name)
           client.updateCursor(Cursor.fromJSON(cursor))
         } else {
           client.removeCursor()

--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -16,7 +16,7 @@ firepad.FirebaseAdapter = (function (global) {
   // Save a checkpoint every 100 edits.
   var CHECKPOINT_FREQUENCY = 100;
 
-  function FirebaseAdapter(ref, userId, userColor) {
+  function FirebaseAdapter(ref, userId, userColor, userName) {
     this.ref_ = ref;
     this.ready_ = false;
     this.firebaseCallbacks_ = [];
@@ -44,6 +44,9 @@ firepad.FirebaseAdapter = (function (global) {
 
       if (userColor) {
         this.setColor(userColor);
+      }
+      if (userName) {
+        this.setName(userName)
       }
 
       var connectedRef = ref.root.child(".info/connected");
@@ -192,6 +195,11 @@ firepad.FirebaseAdapter = (function (global) {
     this.color_ = color;
   };
 
+  FirebaseAdapter.prototype.setName = function (name) {
+    this.userRef_.child("name").set(name);
+    this.name_ = name;
+  };
+
   FirebaseAdapter.prototype.getDocument = function () {
     return this.document_;
   };
@@ -209,7 +217,7 @@ firepad.FirebaseAdapter = (function (global) {
     function childChanged(childSnap) {
       var userId = childSnap.key;
       var userData = childSnap.val();
-      self.trigger("cursor", userId, userData.cursor, userData.color);
+      self.trigger("cursor", userId, userData.cursor, userData.color, userData.name);
     }
 
     this.firebaseOn_(usersRef, "child_added", childChanged);

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -27,6 +27,7 @@ firepad.Firepad = (function (global) {
 
     this.zombie_ = false
 
+    this.editorLib = editorLib
     if (editorLib === 'CodeMirror') {
       this.codeMirror_ = this.editor_ = place
       var curValue = this.codeMirror_.getValue()
@@ -180,7 +181,7 @@ firepad.Firepad = (function (global) {
     }
 
     // For monaco we don't create a wrapper
-    if (this.firepadWrapper_ !== editorWrapper) {
+    if (this.editorLib !== 'Monaco') {
       this.firepadWrapper_.removeChild(editorWrapper)
       this.firepadWrapper_.parentNode.replaceChild(editorWrapper, this.firepadWrapper_)
     }

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -20,7 +20,7 @@ firepad.Firepad = (function (global) {
   var CodeMirror = global.CodeMirror
   var ace = global.ace
 
-  function Firepad(editorLib, ref, place, options) {
+  function Firepad(editorLib, ref, place, options, globalObject) {
     if (!(this instanceof Firepad)) {
       return new Firepad(editorLib, ref, place, options)
     }
@@ -101,7 +101,7 @@ firepad.Firepad = (function (global) {
     } else if (this.ace_) {
       this.editorAdapter_ = new ACEAdapter(this.ace_)
     } else {
-      this.editorAdapter_ = new MonacoAdapter(this.monaco_)
+      this.editorAdapter_ = new MonacoAdapter(globalObject, this.monaco_)
     }
     this.client_ = new EditorClient(this.firebaseAdapter_, this.editorAdapter_)
 
@@ -201,13 +201,13 @@ firepad.Firepad = (function (global) {
     this.assertReady_('getText')
     if (this.codeMirror_) return this.richTextCodeMirror_.getText()
     else if (this.ace_) return this.ace_.getSession().getDocument().getValue()
-    else return this.monaco_.getModel().getValue()
+    else return this.monaco_.getValue()
   }
 
   Firepad.prototype.setText = function (textPieces) {
     this.assertReady_('setText')
     if (this.monaco_) {
-      return this.monaco_.getModel().setValue(textPieces)
+      return this.monaco_.setValue(textPieces)
     } else if (this.ace_) {
       return this.ace_.getSession().getDocument().setValue(textPieces)
     } else {

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -98,7 +98,7 @@ firepad.Firepad = (function (global) {
     } else if (this.ace_) {
       this.editorAdapter_ = new ACEAdapter(this.ace_)
     } else {
-      this.editorAdapter_ = new MonacoAdapter(globalObject, this.monaco_)
+      this.editorAdapter_ = new MonacoAdapter(globalObject, this.monaco_, this.getOption('cursorOptions', {}))
     }
     this.client_ = new EditorClient(this.firebaseAdapter_, this.editorAdapter_)
 

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -29,25 +29,25 @@ firepad.Firepad = (function (global) {
 
     this.editorLib = editorLib
     if (editorLib === 'CodeMirror') {
-      this.codeMirror_ = this.editor_ = place
+      this.codeMirror_ = this.place_ = place
       var curValue = this.codeMirror_.getValue()
       if (curValue !== '') {
         throw new Error("Can't initialize Firepad with a CodeMirror instance that already contains text.")
       }
     } else if (editorLib === 'Ace') {
-      this.ace_ = this.editor_ = place
+      this.ace_ = this.place_ = place
       curValue = this.ace_.getValue()
       if (curValue !== '') {
         throw new Error("Can't initialize Firepad with an ACE instance that already contains text.")
       }
     } else if (editorLib === 'Monaco') {
-      this.monaco_ = this.editor_ = place
+      this.monaco_ = this.place_ = place
       curValue = this.monaco_.getValue()
       if (curValue !== '') {
         throw new Error("Can't initialize Firepad with a Monaco instance that already contains text.")
       }
     } else {
-      this.codeMirror_ = this.editor_ = new CodeMirror(place)
+      this.codeMirror_ = this.place_ = new CodeMirror(place)
     }
 
     var editorWrapper
@@ -65,7 +65,7 @@ firepad.Firepad = (function (global) {
     }
 
     // Provide an easy way to get the firepad instance associated with this CodeMirror instance.
-    this.editor_.firepad = this
+    this.place_.firepad = this
 
     this.options_ = options || {}
 
@@ -180,7 +180,7 @@ firepad.Firepad = (function (global) {
       this.firepadWrapper_.parentNode.replaceChild(editorWrapper, this.firepadWrapper_)
     }
 
-    this.editor_.firepad = null
+    this.place_.firepad = null
 
     if (this.codeMirror_ && this.codeMirror_.getOption('keyMap') === 'richtext') {
       this.codeMirror_.setOption('keyMap', 'default')

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -55,14 +55,10 @@ firepad.Firepad = (function (global) {
       editorWrapper = this.codeMirror_.getWrapperElement()
     } else if (editorLib === 'Ace') {
       editorWrapper = this.ace_.container
-    } else {
-      editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
-    if (editorLib === 'Monaco') {
+    if (editorLib !== 'Monaco') {
       // Do not create a wrapper for monaco
-      this.firepadWrapper_ = editorWrapper
-    } else {
       this.firepadWrapper_ = utils.elt('div', null, { class: 'firepad' })
       editorWrapper.parentNode.replaceChild(this.firepadWrapper_, editorWrapper)
       this.firepadWrapper_.appendChild(editorWrapper)
@@ -176,12 +172,10 @@ firepad.Firepad = (function (global) {
       editorWrapper = this.codeMirror_.getWrapperElement()
     } else if (this.ace_) {
       editorWrapper = this.ace_.container
-    } else {
-      editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
     // For monaco we don't create a wrapper
-    if (this.editorLib !== 'Monaco') {
+    if (editorWrapper != null) {
       this.firepadWrapper_.removeChild(editorWrapper)
       this.firepadWrapper_.parentNode.replaceChild(editorWrapper, this.firepadWrapper_)
     }

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -85,10 +85,11 @@ firepad.Firepad = (function (global) {
 
     var userId = this.getOption('userId', ref.push().key)
     var userColor = this.getOption('userColor', colorFromUserId(userId))
+    var userName = this.getOption('userName', 'Unknown')
 
     this.entityManager_ = new EntityManager()
 
-    this.firebaseAdapter_ = new FirebaseAdapter(ref, userId, userColor)
+    this.firebaseAdapter_ = new FirebaseAdapter(ref, userId, userColor, userName)
     if (this.codeMirror_) {
       this.richTextCodeMirror_ = new RichTextCodeMirror(this.codeMirror_, this.entityManager_, {
         cssPrefix: 'firepad-',

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -194,6 +194,10 @@ firepad.Firepad = (function (global) {
     this.firebaseAdapter_.setColor(color)
   }
 
+  Firepad.prototype.setUserName = function (name) {
+    this.firebaseAdapter_.setName(name)
+  }
+
   Firepad.prototype.getText = function () {
     this.assertReady_('getText')
     if (this.codeMirror_) return this.richTextCodeMirror_.getText()

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -119,11 +119,8 @@ firepad.Firepad = (function (global) {
     this.firebaseAdapter_.on('ready', function () {
       self.ready_ = true
 
-      if (this.ace_) {
-        this.editorAdapter_.grabDocumentState()
-      }
-      if (this.monaco_) {
-        this.editorAdapter_.grabDocumentState()
+      if (self.ace_) {
+        self.editorAdapter_.grabDocumentState()
       }
 
       var defaultText = self.getOption('defaultText', null)

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -42,10 +42,6 @@ firepad.Firepad = (function (global) {
       }
     } else if (editorLib === 'Monaco') {
       this.monaco_ = this.place_ = place
-      curValue = this.monaco_.getValue()
-      if (curValue !== '') {
-        throw new Error("Can't initialize Firepad with a Monaco instance that already contains text.")
-      }
     } else {
       this.codeMirror_ = this.place_ = new CodeMirror(place)
     }

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -165,6 +165,7 @@ firepad.Firepad = (function (global) {
 
     // Unwrap the editor.
     // var editorWrapper = this.codeMirror_ ? this.codeMirror_.getWrapperElement() : this.ace_.container;
+    var editorWrapper
     if (this.codeMirror_) {
       editorWrapper = this.codeMirror_.getWrapperElement()
     } else if (this.ace_) {

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -19,35 +19,27 @@ firepad.Firepad = (function (global) {
   var LIST_TYPE = firepad.LineFormatting.LIST_TYPE
   var CodeMirror = global.CodeMirror
   var ace = global.ace
-  var monaco = global.monaco
 
-  function Firepad(ref, place, options) {
+  function Firepad(editorLib, ref, place, options) {
     if (!(this instanceof Firepad)) {
-      return new Firepad(ref, place, options)
-    }
-
-    if (!CodeMirror && !ace && !global.monaco) {
-      throw new Error(
-        "Couldn't find CodeMirror, ACE or Monaco.  Did you forget to include codemirror.js/ace.js or import monaco?"
-      )
+      return new Firepad(editorLib, ref, place, options)
     }
 
     this.zombie_ = false
 
-    if (CodeMirror && place instanceof CodeMirror) {
+    if (editorLib === 'CodeMirror') {
       this.codeMirror_ = this.editor_ = place
       var curValue = this.codeMirror_.getValue()
       if (curValue !== '') {
         throw new Error("Can't initialize Firepad with a CodeMirror instance that already contains text.")
       }
-    } else if (ace && place && place.session instanceof ace.EditSession) {
+    } else if (editorLib === 'Ace') {
       this.ace_ = this.editor_ = place
       curValue = this.ace_.getValue()
       if (curValue !== '') {
         throw new Error("Can't initialize Firepad with an ACE instance that already contains text.")
       }
-    } else if (global.monaco && place && place instanceof global.monaco.constructor) {
-      monaco = global.monaco
+    } else if (editorLib === 'Monaco') {
       this.monaco_ = this.editor_ = place
       curValue = this.monaco_.getValue()
       if (curValue !== '') {
@@ -58,15 +50,15 @@ firepad.Firepad = (function (global) {
     }
 
     var editorWrapper
-    if (this.codeMirror_) {
+    if (editorLib === 'CodeMirror') {
       editorWrapper = this.codeMirror_.getWrapperElement()
-    } else if (this.ace_) {
+    } else if (editorLib === 'Ace') {
       editorWrapper = this.ace_.container
     } else {
       editorWrapper = this.monaco_.getDomNode().parentNode
     }
 
-    if (this.monaco_ != null) {
+    if (editorLib === 'Monaco') {
       // Do not create a wrapper for monaco
       this.firepadWrapper_ = editorWrapper
     } else {
@@ -170,9 +162,9 @@ firepad.Firepad = (function (global) {
   utils.makeEventEmitter(Firepad)
 
   // For readability, these are the primary "constructors", even though right now they're just aliases for Firepad.
-  Firepad.fromCodeMirror = Firepad
-  Firepad.fromACE = Firepad
-  Firepad.fromMonaco = Firepad
+  Firepad.fromCodeMirror = Firepad.bind(undefined, 'CodeMirror')
+  Firepad.fromACE = Firepad.bind(undefined, 'Ace')
+  Firepad.fromMonaco = Firepad.bind(undefined, 'Monaco')
 
   Firepad.prototype.dispose = function () {
     this.zombie_ = true // We've been disposed.  No longer valid to do anything.

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -209,7 +209,7 @@ var MonacoAdapter = function () {
    * @param {String} color - Hex Color codes for Styling
    * @param {any} clientID - ID number of the Remote Client
    */
-  MonacoAdapter.prototype.setOtherCursor = function setOtherCursor(cursor, color, clientID) {
+  MonacoAdapter.prototype.setOtherCursor = function setOtherCursor(cursor, color, clientID, name) {
     /** House Keeping */
     if (typeof cursor !== 'object' || typeof cursor.position !== 'number'
       || typeof cursor.selectionEnd !== 'number') {
@@ -239,6 +239,7 @@ var MonacoAdapter = function () {
       otherCursor = {
         clientID: clientID,
         color,
+        name,
         position: cursor.position,
         selectionEnd: cursor.selectionEnd
       };
@@ -280,10 +281,10 @@ var MonacoAdapter = function () {
     }
 
     if (otherCursor.cursor == null) {
-      otherCursor.cursor = this.remoteCursorManager.addCursor(otherCursor.clientID, otherCursor.color, otherCursor.clientID)
+      otherCursor.cursor = this.remoteCursorManager.addCursor(otherCursor.clientID, otherCursor.color, otherCursor.name)
     }
     if (otherCursor.selection == null) {
-      otherCursor.selection = this.remoteSelectionManager.addSelection(otherCursor.clientID, otherCursor.color, otherCursor.clientID)
+      otherCursor.selection = this.remoteSelectionManager.addSelection(otherCursor.clientID, otherCursor.color, otherCursor.name)
     }
     if (otherCursor.position === otherCursor.selectionEnd) {
       otherCursor.selection.hide()

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const MonacoCollabExt = require('@convergencelabs/monaco-collab-ext')
+
 /**
  * @function getCSS - For Internal Usage Only
  * @param {String} clazz - CSS Class Name
@@ -104,7 +106,7 @@ var MonacoAdapter = function () {
       this.didChangeCursorPositionHandler.dispose();
 
       for (const otherCursor of this.otherCursors) {
-        otherCursor.decoration = []
+        this.removeOtherCursorDecoration(otherCursor)
       }
     }
   }
@@ -121,6 +123,15 @@ var MonacoAdapter = function () {
         this.didFocusHandler = this.monacoEditor.onDidFocusEditorWidget(this.onFocus);
         this.didChangeCursorPositionHandler = this.monacoEditor.onDidChangeCursorPosition(this.onCursorActivity);
         this.lastCursorRange = this.monacoEditor.getSelection();
+
+        this.remoteCursorManager = new MonacoCollabExt.RemoteCursorManager({
+          editor: newEditor,
+          tooltips: true,
+          tooltipDuration: 2
+        });
+        this.remoteSelectionManager = new MonacoCollabExt.RemoteSelectionManager({
+          editor: newEditor
+        })
 
         this.updateOtherCursors()
       }
@@ -227,7 +238,6 @@ var MonacoAdapter = function () {
     if (!otherCursor) {
       otherCursor = {
         clientID: clientID,
-        decoration: [],
         color,
         position: cursor.position,
         selectionEnd: cursor.selectionEnd
@@ -254,11 +264,14 @@ var MonacoAdapter = function () {
   }
 
   MonacoAdapter.prototype.removeOtherCursorDecoration = function removeOtherCursorDecoration(otherCursor) {
-    if (this.monacoEditor == null) {
-      return
+    if (otherCursor.cursor != null) {
+      otherCursor.cursor.dispose()
+      otherCursor.cursor = undefined
     }
-
-    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
+    if (otherCursor.selection != null) {
+      otherCursor.selection.dispose()
+      otherCursor.selection = undefined
+    }
   }
 
   MonacoAdapter.prototype.updateOtherCursorDecoration = function updateOtherCursorDecoration(otherCursor) {
@@ -266,50 +279,24 @@ var MonacoAdapter = function () {
       return
     }
 
-    /** Remove Earlier Decorations, if any, or initialize empty decor */
-    this.removeOtherCursorDecoration(otherCursor)
-
-    var clazz = "other-client-selection-" + otherCursor.color.replace('#', '');
-    var css, ret;
-
-
-    /** Get co-ordinate position in Editor */
-    var start = this.monacoModel.getPositionAt(Math.min(otherCursor.position, otherCursor.selectionEnd));
-    var end = this.monacoModel.getPositionAt(Math.max(otherCursor.position, otherCursor.selectionEnd));
-
+    if (otherCursor.cursor == null) {
+      otherCursor.cursor = this.remoteCursorManager.addCursor(otherCursor.clientID, otherCursor.color, otherCursor.clientID)
+    }
+    if (otherCursor.selection == null) {
+      otherCursor.selection = this.remoteSelectionManager.addSelection(otherCursor.clientID, otherCursor.color, otherCursor.clientID)
+    }
     if (otherCursor.position === otherCursor.selectionEnd) {
-      /** Show only cursor */
-      clazz = clazz.replace('selection', 'cursor');
-
-      /** Generate Style rules and add them to document */
-      css = getCSS(clazz, 'transparent', otherCursor.color);
-      ret = addStyleRule.call(this, clazz, css);
+      otherCursor.selection.hide()
+      otherCursor.cursor.setOffset(otherCursor.position)
+      otherCursor.cursor.show()
     } else {
-      /** Generate Style rules and add them to document */
-      css = getCSS(clazz, otherCursor.color, otherCursor.color);
-      ret = addStyleRule.call(this, clazz, css);
+      otherCursor.cursor.hide()
+      otherCursor.selection.setOffsets(
+        Math.min(otherCursor.position, otherCursor.selectionEnd),
+        Math.max(otherCursor.position, otherCursor.selectionEnd)
+      )
+      otherCursor.selection.show()
     }
-
-    /** Return if failed to add css */
-    if (ret == false) {
-      console.log("Monaco Adapter: Failed to add some css style.\n"
-      + "Please make sure you're running on supported environment.");
-    }
-
-    /** Add decoration to the Editor */
-    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration,
-      [
-        {
-          range: new monaco.Range(
-            start.lineNumber, start.column,
-            end.lineNumber, end.column
-          ),
-          options: {
-            className: clazz
-          }
-        }
-      ]
-    );
   };
 
   /**

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -3,41 +3,6 @@
 const MonacoCollabExt = require('@convergencelabs/monaco-collab-ext')
 
 /**
- * @function getCSS - For Internal Usage Only
- * @param {String} clazz - CSS Class Name
- * @param {String} bgColor - Background Color
- * @param {String} color - Font Color
- * @returns CSS Style Rules according to Parameters
- */
-var getCSS = function getCSS(clazz, bgColor, color) {
-  return "." + clazz + " {\n  position: relative;\n" +
-    "background-color: " + bgColor + ";\n" +
-    "border-left: 2px solid " + color + ";\n}";
-};
-
-/**
- * @function addStyleRule - For Internal Usage Only
- * @desc Creates style element in document head and pushed all the style rules
- * @param {String} clazz - CSS Class Name
- * @param {String} css - CSS Style Rules
- */
-var addStyleRule = function addStyleRule(clazz, css) {
-  /** House Keeping */
-  if (typeof document === 'undefined' || document === null) {
-    return false;
-  }
-
-  /** Add style rules only once */
-  if (this.addedStyleRules.indexOf(clazz) === -1) {
-    var styleElement = document.createElement('style');
-    var styleSheet = document.createTextNode(css);
-    styleElement.appendChild(styleSheet);
-    document.head.appendChild(styleElement);
-    this.addedStyleRules.push(clazz);
-  }
-};
-
-/**
  * Monaco Adapter
  * Create Pipe between Firebase and Monaco Text Editor
  */

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -57,20 +57,19 @@ var MonacoAdapter = function () {
    * @prop {MonacoIDisposable} didFocusHandler - Event Handler for Focus Gain on Editor Text/Widget
    * @prop {MonacoIDisposable} didChangeCursorPositionHandler - Event Handler for Cursor Position Change
    */
-  function MonacoAdapter(monacoEditor) {
+  function MonacoAdapter(monacoNamespace, monacoModel) {
     /** House Keeping */
 
     // Make sure this looks like a valid monaco instance.
-    if (!monacoEditor || typeof monacoEditor.getModel !== 'function') {
+    if (!monacoModel || typeof monacoModel.getValue !== 'function') {
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
-        + 'expected valid Monaco Editor Instance');
+        + 'expected valid Monaco Model Instance');
     }
 
     /** Monaco Member Variables */
-    this.monacoEditor = monacoEditor;
-    this.monacoModel = this.monacoEditor.getModel();
+    this.monacoNamespace = monacoNamespace;
+    this.monacoModel = monacoModel;
     this.lastDocLines = this.monacoModel.getLinesContent();
-    this.lastCursorRange = this.monacoEditor.getSelection();
 
     /** Monaco Editor Configurations */
     this.callbacks = {};
@@ -84,21 +83,56 @@ var MonacoAdapter = function () {
     this.onFocus = this.onFocus.bind(this);
     this.onCursorActivity = this.onCursorActivity.bind(this);
 
-    /** Editor Callback Handler */
-    this.changeHandler = this.monacoEditor.onDidChangeModelContent(this.onChange);
-    this.didBlurHandler = this.monacoEditor.onDidBlurEditorWidget(this.onBlur);
-    this.didFocusHandler = this.monacoEditor.onDidFocusEditorWidget(this.onFocus);
-    this.didChangeCursorPositionHandler = this.monacoEditor.onDidChangeCursorPosition(this.onCursorActivity);
+    this.changeHandler = this.monacoModel.onDidChangeContent(this.onChange);
+
+    this.didChangeAttachedHandler = this.monacoModel.onDidChangeAttached(() => {
+      // Monaco editor is lying, this callback is called BEFORE the model is changed
+      setImmediate(() => {
+        this.initEditor()
+      })
+    })
+    this.initEditor()
+  }
+
+  MonacoAdapter.prototype.detachEditor = function detachEditor() {
+    if (this.monacoEditor != null) {
+      this.onBlur()
+      this.monacoEditor = null
+      this.didBlurHandler.dispose();
+      this.didFocusHandler.dispose();
+      this.didChangeCursorPositionHandler.dispose();
+
+      for (const otherCursor of this.otherCursors) {
+        otherCursor.decoration = []
+      }
+    }
+  }
+
+  MonacoAdapter.prototype.initEditor = function initEditor() {
+    const newEditor = this.monacoNamespace.editor.getEditors().find(editor => editor.getModel() === this.monacoModel)
+
+    if (newEditor != this.monacoEditor) {
+      this.detachEditor()
+      /** Editor Callback Handler */
+      this.monacoEditor = newEditor
+      if (this.monacoEditor != null) {
+        this.didBlurHandler = this.monacoEditor.onDidBlurEditorWidget(this.onBlur);
+        this.didFocusHandler = this.monacoEditor.onDidFocusEditorWidget(this.onFocus);
+        this.didChangeCursorPositionHandler = this.monacoEditor.onDidChangeCursorPosition(this.onCursorActivity);
+        this.lastCursorRange = this.monacoEditor.getSelection();
+
+        this.updateOtherCursors()
+      }
+    }
   }
 
   /**
    * @method detach - Clears an Instance of Editor Adapter
    */
   MonacoAdapter.prototype.detach = function detach() {
+    this.detachEditor()
     this.changeHandler.dispose();
-    this.didBlurHandler.dispose();
-    this.didFocusHandler.dispose();
-    this.didChangeCursorPositionHandler.dispose();
+    this.didChangeAttachedHandler.dispose()
   };
 
   /**
@@ -106,6 +140,9 @@ var MonacoAdapter = function () {
    * @returns Firepad Cursor object
    */
   MonacoAdapter.prototype.getCursor = function getCursor() {
+    if (this.monacoEditor == null) {
+      return null
+    }
     var selection = this.monacoEditor.getSelection();
 
     /** Fallback to last cursor change */
@@ -119,15 +156,8 @@ var MonacoAdapter = function () {
     var start = this.monacoModel.getOffsetAt(startPos);
     var end = this.monacoModel.getOffsetAt(endPos);
 
-    /** If Selection is Inversed */
-    if (start > end) {
-      var _ref = [end, start];
-      start = _ref[0];
-      end = _ref[1];
-    }
-
     /** Return cursor position */
-    return new firepad.Cursor(start, end);
+    return new firepad.Cursor(Math.min(start, end), Math.max(start, end));
   };
 
   /**
@@ -137,17 +167,13 @@ var MonacoAdapter = function () {
    * @param {Number} cursor.selectionEnd - Ending Position of the Cursor
    */
   MonacoAdapter.prototype.setCursor = function setCursor(cursor) {
+    if (this.monacoEditor == null) {
+      return
+    }
     var position = cursor.position;
     var selectionEnd = cursor.selectionEnd;
-    var start = this.monacoModel.getPositionAt(position);
-    var end = this.monacoModel.getPositionAt(selectionEnd);
-
-    /** If selection is inversed */
-    if (position > selectionEnd) {
-      var _ref = [end, start];
-      start = _ref[0];
-      end = _ref[1];
-    }
+    var start = this.monacoModel.getPositionAt(Math.min(position, selectionEnd));
+    var end = this.monacoModel.getPositionAt(Math.max(position, selectionEnd));
 
     /** Create Selection in the Editor */
     this.monacoEditor.setSelection(
@@ -157,6 +183,12 @@ var MonacoAdapter = function () {
       )
     );
   };
+
+  MonacoAdapter.prototype.updateOtherCursors = function updateOtherCursors() {
+    for (const otherCursor of this.otherCursors) {
+      this.updateOtherCursorDecoration(otherCursor)
+    }
+  }
 
   /**
    * @method setOtherCursor - Set Remote Selection on Monaco Editor
@@ -194,26 +226,66 @@ var MonacoAdapter = function () {
     if (!otherCursor) {
       otherCursor = {
         clientID: clientID,
-        decoration: []
+        decoration: [],
+        color,
+        position: cursor.position,
+        selectionEnd: cursor.selectionEnd
       };
       this.otherCursors.push(otherCursor);
+    } else {
+      otherCursor.position = cursor.position
+      otherCursor.selectionEnd = cursor.selectionEnd
+    }
+
+    this.updateOtherCursorDecoration(otherCursor)
+
+    /** Clear cursor method */
+    var _this = this;
+    return {
+      clear: function clear() {
+        const index = _this.otherCursors.indexOf(otherCursor)
+        if (index >= 0) {
+          _this.otherCursors.splice(index, 1)
+        }
+        _this.removeOtherCursorDecoration(otherCursor)
+      }
+    };
+  }
+
+  MonacoAdapter.prototype.removeOtherCursorDecoration = function removeOtherCursorDecoration(otherCursor) {
+    if (this.monacoEditor == null) {
+      return
+    }
+
+    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
+  }
+
+  MonacoAdapter.prototype.updateOtherCursorDecoration = function updateOtherCursorDecoration(otherCursor) {
+    if (this.monacoEditor == null) {
+      return
     }
 
     /** Remove Earlier Decorations, if any, or initialize empty decor */
-    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
-    var clazz = "other-client-selection-" + color.replace('#', '');
+    this.removeOtherCursorDecoration(otherCursor)
+
+    var clazz = "other-client-selection-" + otherCursor.color.replace('#', '');
     var css, ret;
 
-    if (position === selectionEnd) {
+
+    /** Get co-ordinate position in Editor */
+    var start = this.monacoModel.getPositionAt(Math.min(otherCursor.position, otherCursor.selectionEnd));
+    var end = this.monacoModel.getPositionAt(Math.max(otherCursor.position, otherCursor.selectionEnd));
+
+    if (otherCursor.position === otherCursor.selectionEnd) {
       /** Show only cursor */
       clazz = clazz.replace('selection', 'cursor');
 
       /** Generate Style rules and add them to document */
-      css = getCSS(clazz, 'transparent', color);
+      css = getCSS(clazz, 'transparent', otherCursor.color);
       ret = addStyleRule.call(this, clazz, css);
     } else {
       /** Generate Style rules and add them to document */
-      css = getCSS(clazz, color, color);
+      css = getCSS(clazz, otherCursor.color, otherCursor.color);
       ret = addStyleRule.call(this, clazz, css);
     }
 
@@ -221,17 +293,6 @@ var MonacoAdapter = function () {
     if (ret == false) {
       console.log("Monaco Adapter: Failed to add some css style.\n"
       + "Please make sure you're running on supported environment.");
-    }
-
-    /** Get co-ordinate position in Editor */
-    var start = this.monacoModel.getPositionAt(position);
-    var end = this.monacoModel.getPositionAt(selectionEnd);
-
-    /** Selection is inversed */
-    if (position > selectionEnd) {
-      var _ref = [end, start];
-      start = _ref[0];
-      end = _ref[1];
     }
 
     /** Add decoration to the Editor */
@@ -248,14 +309,6 @@ var MonacoAdapter = function () {
         }
       ]
     );
-
-    /** Clear cursor method */
-    var _this = this;
-    return {
-      clear: function clear() {
-        otherCursor.decoration = _this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
-      }
-    };
   };
 
   /**
@@ -417,7 +470,7 @@ var MonacoAdapter = function () {
    * @method onBlur - Blur event handler
    */
   MonacoAdapter.prototype.onBlur = function onBlur() {
-    if (this.monacoEditor.getSelection().isEmpty()) {
+    if (this.monacoEditor == null || this.monacoEditor.getSelection() == null || this.monacoEditor.getSelection().isEmpty()) {
       this.trigger('blur');
     }
   };
@@ -466,7 +519,7 @@ var MonacoAdapter = function () {
         /** Insert Operation */
         var pos = _this.monacoModel.getPositionAt(index);
 
-        _this.monacoEditor.executeEdits('my-source', [{
+        _this.monacoModel.applyEdits([{
           range: new monaco.Range(
             pos.lineNumber, pos.column,
             pos.lineNumber, pos.column
@@ -481,7 +534,7 @@ var MonacoAdapter = function () {
         var from = _this.monacoModel.getPositionAt(index);
         var to = _this.monacoModel.getPositionAt(index + op.chars);
 
-        _this.monacoEditor.executeEdits('my-source', [{
+        _this.monacoModel.applyEdits([{
           range: new monaco.Range(
             from.lineNumber, from.column,
             to.lineNumber, to.column

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -189,7 +189,7 @@ var MonacoAdapter = function () {
 
     /** Create Selection in the Editor */
     this.monacoEditor.setSelection(
-      new monaco.Range(
+      new this.monacoNamespace.Range(
         start.lineNumber, start.column,
         end.lineNumber, end.column
       )
@@ -538,7 +538,7 @@ var MonacoAdapter = function () {
           var pos = _this.monacoModel.getPositionAt(index);
 
           _this.monacoModel.applyEdits([{
-            range: new monaco.Range(
+            range: new this.monacoNamespace.Range(
               pos.lineNumber, pos.column,
               pos.lineNumber, pos.column
             ),
@@ -553,7 +553,7 @@ var MonacoAdapter = function () {
           var to = _this.monacoModel.getPositionAt(index + op.chars);
 
           _this.monacoModel.applyEdits([{
-            range: new monaco.Range(
+            range: new this.monacoNamespace.Range(
               from.lineNumber, from.column,
               to.lineNumber, to.column
             ),

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -528,40 +528,44 @@ var MonacoAdapter = function () {
       }
     } else {
       var index = 0;
-      var _this = this;
-      opsList.forEach(function (op) {
+      const monacoModel = this.monacoModel
+      const edits = opsList.flatMap(op => {
         /** Retain Operation */
         if (op.isRetain()) {
           index += op.chars;
         } else if (op.isInsert()) {
           /** Insert Operation */
-          var pos = _this.monacoModel.getPositionAt(index);
+          var pos = monacoModel.getPositionAt(index);
 
-          _this.monacoModel.applyEdits([{
+          return [{
             range: new this.monacoNamespace.Range(
               pos.lineNumber, pos.column,
               pos.lineNumber, pos.column
             ),
             text: op.text,
             forceMoveMarkers: true
-          }]);
-
-          index += op.text.length;
+          }];
         } else if (op.isDelete()) {
           /** Delete Operation */
-          var from = _this.monacoModel.getPositionAt(index);
-          var to = _this.monacoModel.getPositionAt(index + op.chars);
+          var from = monacoModel.getPositionAt(index);
+          var to = monacoModel.getPositionAt(index + op.chars);
 
-          _this.monacoModel.applyEdits([{
+          index += op.chars;
+
+          return [{
             range: new this.monacoNamespace.Range(
               from.lineNumber, from.column,
               to.lineNumber, to.column
             ),
             text: '',
             forceMoveMarkers: true
-          }]);
+          }];
         }
+
+        return []
       });
+
+      monacoModel.applyEdits(edits)
     }
 
     /** Restore whitespace auto-trim setting */

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -63,12 +63,12 @@ var MonacoAdapter = function () {
     // Make sure this looks like a valid monaco instance.
     if (!monacoEditor || typeof monacoEditor.getModel !== 'function') {
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
-        + 'expected valid Monaco Instance');
+        + 'expected valid Monaco Editor Instance');
     }
 
     /** Monaco Member Variables */
-    this.monacoEditor = monacoInstance;
-    this.monacoModel = this.monaco.getModel();
+    this.monacoEditor = monacoEditor;
+    this.monacoModel = this.monacoEditor.getModel();
     this.lastDocLines = this.monacoModel.getLinesContent();
     this.lastCursorRange = this.monacoEditor.getSelection();
 

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -70,6 +70,7 @@ var MonacoAdapter = function () {
     this.monacoNamespace = monacoNamespace;
     this.monacoModel = monacoModel;
     this.lastDocLines = this.monacoModel.getLinesContent();
+    this.initialized = false
 
     /** Monaco Editor Configurations */
     this.callbacks = {};
@@ -508,42 +509,64 @@ var MonacoAdapter = function () {
 
     /** Get Operations List */
     var opsList = operation.ops;
-    var index = 0;
 
-    var _this = this;
-    opsList.forEach(function (op) {
-      /** Retain Operation */
-      if (op.isRetain()) {
-        index += op.chars;
-      } else if (op.isInsert()) {
-        /** Insert Operation */
-        var pos = _this.monacoModel.getPositionAt(index);
-
-        _this.monacoModel.applyEdits([{
-          range: new monaco.Range(
-            pos.lineNumber, pos.column,
-            pos.lineNumber, pos.column
-          ),
-          text: op.text,
-          forceMoveMarkers: true
-        }]);
-
-        index += op.text.length;
-      } else if (op.isDelete()) {
-        /** Delete Operation */
-        var from = _this.monacoModel.getPositionAt(index);
-        var to = _this.monacoModel.getPositionAt(index + op.chars);
-
-        _this.monacoModel.applyEdits([{
-          range: new monaco.Range(
-            from.lineNumber, from.column,
-            to.lineNumber, to.column
-          ),
-          text: '',
-          forceMoveMarkers: true
+    if (!this.initialized) {
+      this.initialized = true
+      if (opsList.length === 1 && opsList[0].isInsert()) {
+        const insertOp = opsList[0]
+        if (insertOp.text === this.monacoModel.getValue()) {
+          // Model already up to date
+        } else {
+          // Replace the content
+          this.monacoModel.applyEdits([{
+            range: this.monacoModel.getFullModelRange(),
+            text: insertOp.text
+          }]);
+        }
+      } else {
+        // Empty the model
+        this.monacoModel.applyEdits([{
+          range: this.monacoModel.getFullModelRange(),
+          text: ''
         }]);
       }
-    });
+    } else {
+      var index = 0;
+      var _this = this;
+      opsList.forEach(function (op) {
+        /** Retain Operation */
+        if (op.isRetain()) {
+          index += op.chars;
+        } else if (op.isInsert()) {
+          /** Insert Operation */
+          var pos = _this.monacoModel.getPositionAt(index);
+
+          _this.monacoModel.applyEdits([{
+            range: new monaco.Range(
+              pos.lineNumber, pos.column,
+              pos.lineNumber, pos.column
+            ),
+            text: op.text,
+            forceMoveMarkers: true
+          }]);
+
+          index += op.text.length;
+        } else if (op.isDelete()) {
+          /** Delete Operation */
+          var from = _this.monacoModel.getPositionAt(index);
+          var to = _this.monacoModel.getPositionAt(index + op.chars);
+
+          _this.monacoModel.applyEdits([{
+            range: new monaco.Range(
+              from.lineNumber, from.column,
+              to.lineNumber, to.column
+            ),
+            text: '',
+            forceMoveMarkers: true
+          }]);
+        }
+      });
+    }
 
     /** Restore whitespace auto-trim setting */
     this.monacoModel.updateOptions({ trimAutoWhitespace: userWhitespaceSetting })

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -59,7 +59,7 @@ var MonacoAdapter = function () {
    * @prop {MonacoIDisposable} didFocusHandler - Event Handler for Focus Gain on Editor Text/Widget
    * @prop {MonacoIDisposable} didChangeCursorPositionHandler - Event Handler for Cursor Position Change
    */
-  function MonacoAdapter(monacoNamespace, monacoModel) {
+  function MonacoAdapter(monacoNamespace, monacoModel, cursorOptions) {
     /** House Keeping */
 
     // Make sure this looks like a valid monaco instance.
@@ -69,6 +69,7 @@ var MonacoAdapter = function () {
     }
 
     /** Monaco Member Variables */
+    this.cursorOptions = cursorOptions
     this.monacoNamespace = monacoNamespace;
     this.monacoModel = monacoModel;
     this.lastDocLines = this.monacoModel.getLinesContent();
@@ -126,8 +127,7 @@ var MonacoAdapter = function () {
 
         this.remoteCursorManager = new MonacoCollabExt.RemoteCursorManager({
           editor: newEditor,
-          tooltips: true,
-          tooltipDuration: 2
+          ...this.cursorOptions
         });
         this.remoteSelectionManager = new MonacoCollabExt.RemoteSelectionManager({
           editor: newEditor

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -57,20 +57,20 @@ var MonacoAdapter = function () {
    * @prop {MonacoIDisposable} didFocusHandler - Event Handler for Focus Gain on Editor Text/Widget
    * @prop {MonacoIDisposable} didChangeCursorPositionHandler - Event Handler for Cursor Position Change
    */
-  function MonacoAdapter(monacoInstance) {
+  function MonacoAdapter(monacoEditor) {
     /** House Keeping */
 
     // Make sure this looks like a valid monaco instance.
-    if (!monacoInstance || typeof monacoInstance.getModel !== 'function') {
+    if (!monacoEditor || typeof monacoEditor.getModel !== 'function') {
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
         + 'expected valid Monaco Instance');
     }
 
     /** Monaco Member Variables */
-    this.monaco = monacoInstance;
+    this.monacoEditor = monacoInstance;
     this.monacoModel = this.monaco.getModel();
     this.lastDocLines = this.monacoModel.getLinesContent();
-    this.lastCursorRange = this.monaco.getSelection();
+    this.lastCursorRange = this.monacoEditor.getSelection();
 
     /** Monaco Editor Configurations */
     this.callbacks = {};
@@ -85,10 +85,10 @@ var MonacoAdapter = function () {
     this.onCursorActivity = this.onCursorActivity.bind(this);
 
     /** Editor Callback Handler */
-    this.changeHandler = this.monaco.onDidChangeModelContent(this.onChange);
-    this.didBlurHandler = this.monaco.onDidBlurEditorWidget(this.onBlur);
-    this.didFocusHandler = this.monaco.onDidFocusEditorWidget(this.onFocus);
-    this.didChangeCursorPositionHandler = this.monaco.onDidChangeCursorPosition(this.onCursorActivity);
+    this.changeHandler = this.monacoEditor.onDidChangeModelContent(this.onChange);
+    this.didBlurHandler = this.monacoEditor.onDidBlurEditorWidget(this.onBlur);
+    this.didFocusHandler = this.monacoEditor.onDidFocusEditorWidget(this.onFocus);
+    this.didChangeCursorPositionHandler = this.monacoEditor.onDidChangeCursorPosition(this.onCursorActivity);
   }
 
   /**
@@ -106,7 +106,7 @@ var MonacoAdapter = function () {
    * @returns Firepad Cursor object
    */
   MonacoAdapter.prototype.getCursor = function getCursor() {
-    var selection = this.monaco.getSelection();
+    var selection = this.monacoEditor.getSelection();
 
     /** Fallback to last cursor change */
     if (typeof selection === 'undefined' || selection === null) {
@@ -150,7 +150,7 @@ var MonacoAdapter = function () {
     }
 
     /** Create Selection in the Editor */
-    this.monaco.setSelection(
+    this.monacoEditor.setSelection(
       new monaco.Range(
         start.lineNumber, start.column,
         end.lineNumber, end.column
@@ -200,7 +200,7 @@ var MonacoAdapter = function () {
     }
 
     /** Remove Earlier Decorations, if any, or initialize empty decor */
-    otherCursor.decoration = this.monaco.deltaDecorations(otherCursor.decoration, []);
+    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
     var clazz = "other-client-selection-" + color.replace('#', '');
     var css, ret;
 
@@ -235,7 +235,7 @@ var MonacoAdapter = function () {
     }
 
     /** Add decoration to the Editor */
-    otherCursor.decoration = this.monaco.deltaDecorations(otherCursor.decoration,
+    otherCursor.decoration = this.monacoEditor.deltaDecorations(otherCursor.decoration,
       [
         {
           range: new monaco.Range(
@@ -253,7 +253,7 @@ var MonacoAdapter = function () {
     var _this = this;
     return {
       clear: function clear() {
-        otherCursor.decoration = _this.monaco.deltaDecorations(otherCursor.decoration, []);
+        otherCursor.decoration = _this.monacoEditor.deltaDecorations(otherCursor.decoration, []);
       }
     };
   };
@@ -417,7 +417,7 @@ var MonacoAdapter = function () {
    * @method onBlur - Blur event handler
    */
   MonacoAdapter.prototype.onBlur = function onBlur() {
-    if (this.monaco.getSelection().isEmpty()) {
+    if (this.monacoEditor.getSelection().isEmpty()) {
       this.trigger('blur');
     }
   };
@@ -466,7 +466,7 @@ var MonacoAdapter = function () {
         /** Insert Operation */
         var pos = _this.monacoModel.getPositionAt(index);
 
-        _this.monaco.executeEdits('my-source', [{
+        _this.monacoEditor.executeEdits('my-source', [{
           range: new monaco.Range(
             pos.lineNumber, pos.column,
             pos.lineNumber, pos.column
@@ -481,7 +481,7 @@ var MonacoAdapter = function () {
         var from = _this.monacoModel.getPositionAt(index);
         var to = _this.monacoModel.getPositionAt(index + op.chars);
 
-        _this.monaco.executeEdits('my-source', [{
+        _this.monacoEditor.executeEdits('my-source', [{
           range: new monaco.Range(
             from.lineNumber, from.column,
             to.lineNumber, to.column

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -223,13 +223,18 @@ var MonacoAdapter = function () {
     var _this = this;
     return {
       clear: function clear() {
-        const index = _this.otherCursors.indexOf(otherCursor)
-        if (index >= 0) {
-          _this.otherCursors.splice(index, 1)
-        }
-        _this.removeOtherCursorDecoration(otherCursor)
+        _this.hideOtherCursorDecoration(otherCursor)
       }
     };
+  }
+
+  MonacoAdapter.prototype.hideOtherCursorDecoration = function hideOtherCursorDecoration(otherCursor) {
+    if (otherCursor.cursor != null) {
+      otherCursor.cursor.hide()
+    }
+    if (otherCursor.selection != null) {
+      otherCursor.cursor.hide()
+    }
   }
 
   MonacoAdapter.prototype.removeOtherCursorDecoration = function removeOtherCursorDecoration(otherCursor) {

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -9,9 +9,12 @@ const MonacoCollabExt = require('@convergencelabs/monaco-collab-ext')
 var MonacoAdapter = function () {
   /**
    * @constructor MonacoEditor
-   * @param {MonacoEditor} monacoInstance - Editor Instance
-   * @prop {MonacoEditor} monaco - Monaco Instance passed as Parameter
-   * @prop {MonacoITextModel} monacoModel - Data Model of the Monaco Instance
+   * @param {monacoNamespace} monacoNamespace - Monaco editor namespace
+   * @param {monacoModel} monacoModel - Editor Instance
+   * @param {cursorOptions} cursorOptions - monaco-collab-ext cursor options
+   * @prop {monacoNamespace} monacoNamespace - Monaco editor namespace passed as Parameter
+   * @prop {MonacoITextModel} monacoModel - Monaco editor model passed as Parameter
+   * @prop {cursorOptions} cursorOptions - monaco-collab-ext cursor options model passed as Parameter
    * @prop {string[]} lastDocLines - Text for all Lines in the Editor
    * @prop {MonacoSelection} lastCursorRange - Primary Selection of the Editor
    * @prop {function} onChange - Change Event Handler bound Local Object

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -510,6 +510,14 @@ var MonacoAdapter = function () {
             range: this.monacoModel.getFullModelRange(),
             text: insertOp.text
           }]);
+          if (this.monacoEditor != null) {
+            this.monacoEditor.setSelection({
+              startLineNumber: 1,
+              startColumn: 1,
+              endLineNumber: 1,
+              endColumn: 1
+            });
+          }
         }
       } else {
         // Empty the model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "firepad",
+  "name": "@coderpad_io/firepad",
   "version": "1.5.11",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "karma-spec-reporter": "0.0.32",
     "monaco-editor": "^0.20.0"
   },
+  "peerDependencies": {
+    "@convergencelabs/monaco-collab-ext": "^0.3.2"
+  },
   "scripts": {
     "test": "grunt test",
     "travis": "grunt",

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -70,8 +70,8 @@ describe('Integration tests', function() {
     var ref = rootRef.push();
     var cm1 = CodeMirror(hiddenDiv());
     var cm2 = CodeMirror(hiddenDiv());
-    var firepad1 = new Firepad(ref, cm1);
-    var firepad2 = new Firepad(ref, cm2);
+    var firepad1 = new Firepad('CodeMirror', ref, cm1);
+    var firepad2 = new Firepad('CodeMirror', ref, cm2);
 
     firepad1.on('ready', function() {
       firepad1.setText('XXX3456789XXX');
@@ -93,8 +93,8 @@ describe('Integration tests', function() {
     var ref = rootRef.push();
     var cm1 = CodeMirror(hiddenDiv());
     var cm2 = CodeMirror(hiddenDiv());
-    var firepad1 = new Firepad(ref, cm1);
-    var firepad2 = new Firepad(ref, cm2);
+    var firepad1 = new Firepad('CodeMirror', ref, cm1);
+    var firepad2 = new Firepad('CodeMirror', ref, cm2);
 
     function step(times) {
       if (times == 0) {
@@ -119,7 +119,7 @@ describe('Integration tests', function() {
   it('Performs getHtml responsively', function(done) {
     var ref = rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepad = new Firepad(ref, cm);
+    var firepad = new Firepad('CodeMirror', ref, cm);
 
     firepad.on('ready', function() {
       var html = '<b>bold</b>';
@@ -135,7 +135,7 @@ describe('Integration tests', function() {
     var cm2 = CodeMirror(hiddenDiv());
     var text = 'This should be the starting text';
     var text2 = 'this is a new, different text';
-    var firepad = new Firepad(ref, cm, { defaultText: text});
+    var firepad = new Firepad('CodeMirror', ref, cm, { defaultText: text});
 
     firepad.on('ready', function() {
       expect(firepad.getText()).toEqual(text);
@@ -144,7 +144,7 @@ describe('Integration tests', function() {
         firepad.on('synced', function(isSync) { if (isSync) resolve(); });
       });
       waitForSync.then(function() {
-        var firepad2 = new Firepad(ref, cm2, { defaultText: text});
+        var firepad2 = new Firepad('CodeMirror', ref, cm2, { defaultText: text});
         firepad2.on('ready', function() {
           if (firepad2.getText() == text2) {
             done();
@@ -161,7 +161,7 @@ describe('Integration tests', function() {
   it('Emits sync events as users edit the pad', function(done) {
     var ref = rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepad = new Firepad(ref, cm, { defaultText: 'XXXXXXXX' });
+    var firepad = new Firepad('CodeMirror', ref, cm, { defaultText: 'XXXXXXXX' });
     var startedSyncing = false;
 
     firepad.on('ready', function() {
@@ -182,7 +182,7 @@ describe('Integration tests', function() {
   it('Performs Firepad.dispose', function(done){
     var ref = rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepad = new Firepad(ref, cm, { defaultText: "It\'s alive." });
+    var firepad = new Firepad('CodeMirror', ref, cm, { defaultText: "It\'s alive." });
 
     firepad.on('ready', function() {
       firepad.dispose();
@@ -201,7 +201,7 @@ describe('Integration tests', function() {
   it('Safely performs Firepad.dispose immediately after construction', function(){
     var ref =rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepad = new Firepad(ref, cm);
+    var firepad = new Firepad('CodeMirror', ref, cm);
 
     expect(function() {
       firepad.dispose();
@@ -211,7 +211,7 @@ describe('Integration tests', function() {
   it('Performs headless get/set plaintext & dispose', function(done){
     var ref = rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepadCm = new Firepad(ref, cm);
+    var firepadCm = new Firepad('CodeMirror', ref, cm);
     var firepadHeadless = new Headless(ref);
 
     var text = 'Hello from headless firepad!';
@@ -235,7 +235,7 @@ describe('Integration tests', function() {
   it('Performs headless get/set html & dispose', function(done) {
     var ref = rootRef.push();
     var cm = CodeMirror(hiddenDiv());
-    var firepadCm = new Firepad(ref, cm);
+    var firepadCm = new Firepad('CodeMirror', ref, cm);
     var firepadHeadless = new Headless(ref);
 
     var html =
@@ -323,7 +323,7 @@ describe('Integration tests', function() {
     var cm = CodeMirror(hiddenDiv());
 
     expect(function() {
-      var firepad = new Firepad(ref1, cm, { defaultText: 'Default Content'});
+      var firepad = new Firepad('CodeMirror', ref1, cm, { defaultText: 'Default Content'});
       firepad.dispose()
       // Wait some time for the callbacks to get called
       setTimeout(done, 1)
@@ -335,7 +335,7 @@ describe('Integration tests', function() {
     var ref2 = firebase.database().ref('2').push();
 
     var cm = CodeMirror(hiddenDiv());
-    var firepad1 = new Firepad(ref1, cm);
+    var firepad1 = new Firepad('CodeMirror', ref1, cm);
 
     firepad1.on('ready', function() {
       // Add some text to Firepad
@@ -348,7 +348,7 @@ describe('Integration tests', function() {
           cm.setValue('');
 
           // Create a new Firepad, using the same ref which we added text to, then dispose it
-          var firepad2 = new Firepad(ref1, cm);
+          var firepad2 = new Firepad('CodeMirror', ref1, cm);
           firepad2.dispose()
           firepad2.on('ready', () => {
             expect(cm.getValue()).toEqual('Test Content');
@@ -357,7 +357,7 @@ describe('Integration tests', function() {
     
           // Create a new Firepad instance with a different ref
           // Should not contain text from previously disposed firepad
-          var firepad3 = new Firepad(ref2, cm);
+          var firepad3 = new Firepad('CodeMirror', ref2, cm);
           firepad3.on('ready', function(synced) {
             expect(cm.getValue()).toEqual('');
             done();


### PR DESCRIPTION
### Description

It changes the monaco adapter to take a model and the namespace instead of the editor.

It allows to synchronize multiple models at once within a single editor.

It also:
- Removes the need for the monaco namespace to be global
- Removes the need for the model to be empty before passing it to firepad
- Allows to provide an user name along with the user color
- Replaces the internal cursor/selection logic by [monaco-collab-ext](https://github.com/convergencelabs/monaco-collab-ext)
  - There is new options: `cursorOptions`
  - The user name can be displayed
- Cleans dead/wrong code
- merges call to executeEdits/applyEdits (useful for LSP)
