### PR TITLE
[FIX] Prevent showing cursors that have been hidden

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -221,6 +221,7 @@ var MonacoAdapter = function () {
       } else {
         otherCursor.position = cursor.position
         otherCursor.selectionEnd = cursor.selectionEnd
+        otherCursor.visible = true
       }
     }
     /** Initialize empty array, if client does not exist */
@@ -230,7 +231,8 @@ var MonacoAdapter = function () {
         color,
         name,
         position: cursor.position,
-        selectionEnd: cursor.selectionEnd
+        selectionEnd: cursor.selectionEnd,
+        visible: true
       };
       this.otherCursors.push(otherCursor);
     }
@@ -247,6 +249,7 @@ var MonacoAdapter = function () {
   }
 
   MonacoAdapter.prototype.hideOtherCursorDecoration = function hideOtherCursorDecoration(otherCursor) {
+    otherCursor.visible = false
     if (otherCursor.cursor != null) {
       otherCursor.cursor.hide()
     }
@@ -278,17 +281,20 @@ var MonacoAdapter = function () {
       otherCursor.selection = this.remoteSelectionManager.addSelection(otherCursor.clientID, otherCursor.color)
     }
 
-    otherCursor.cursor.setOffset(otherCursor.position)
-    otherCursor.cursor.show()
+    // Prevent showing the cursor if it has been deliberately hidden (eg. on blur)
+    if (otherCursor.visible) {
+      otherCursor.cursor.setOffset(otherCursor.position)
+      otherCursor.cursor.show()
 
-    if (otherCursor.position === otherCursor.selectionEnd) {
-      otherCursor.selection.hide()
-    } else {
-      otherCursor.selection.setOffsets(
-        Math.min(otherCursor.position, otherCursor.selectionEnd),
-        Math.max(otherCursor.position, otherCursor.selectionEnd)
-      )
-      otherCursor.selection.show()
+      if (otherCursor.position === otherCursor.selectionEnd) {
+        otherCursor.selection.hide()
+      } else {
+        otherCursor.selection.setOffsets(
+          Math.min(otherCursor.position, otherCursor.selectionEnd),
+          Math.max(otherCursor.position, otherCursor.selectionEnd)
+        )
+        otherCursor.selection.show()
+      }
     }
   };
 


### PR DESCRIPTION
Bug reproduction steps:
- UserA goes to index.html
- UserB goes to index.html and sees UserA's cursor
- UserA goes to App.tsx and userB doesn't see UserA's cursor in index.html anymore (expected behavior)
- UserB goes to another file (eg. App.tsx) and comes back to index.html

=> UserB sees UserA's last cursor in index.html even though UserA is not currently in index.html

This is due to the fact that we restore cursors when opening a file, and as the cursors are not removed anymore (only hidden to avoid flickering) they are restored even though they have been hidden.

This PR add the `visible` property to a cursor to ensure we don't `show` a hidden cursor